### PR TITLE
Dispatcher fix

### DIFF
--- a/lib/fabrication/fabricator.rb
+++ b/lib/fabrication/fabricator.rb
@@ -43,7 +43,7 @@ class Fabrication::Fabricator
 end
 
 # Adds support for reload! in the Rails 2.3.x console
-if defined? ActionController and ActionController::Dispatcher.respond_to? :reload_application
+if defined? ActionController::Dispatcher and ActionController::Dispatcher.respond_to? :reload_application
   ActionController::Dispatcher.to_prepare :fabrication do
     Fabrication.clear_definitions
   end


### PR DESCRIPTION
So ActionController::Dispatcher removed from rails edge and it's better to check existence of it instead of just ActionController.
