### PR TITLE
Update bson_ext minimal version

### DIFF
--- a/fabrication.gemspec
+++ b/fabrication.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("ffaker", [">= 0.4.0"])
   s.add_development_dependency("activerecord", [">= 3.0.3"])
   s.add_development_dependency("sqlite3-ruby", ["= 1.3.1"])
-  s.add_development_dependency("bson_ext", ["1.1.4"])
+  s.add_development_dependency("bson_ext", [">=1.1.5"])
   s.add_development_dependency("mongoid", ["2.0.0.beta.20"])
   s.add_development_dependency("sequel", ["3.16.0"])
 end


### PR DESCRIPTION
> Able to load bson_ext version 1.1.4, but >= 1.1.5 is required.
> **Notice: C extension not loaded. This is required for optimum MongoDB Ruby driver performance.
>   You can install the extension as follows:
>   gem install bson_ext
