### PR TITLE
more syntactic sugar for sequences

### DIFF
--- a/lib/fabrication.rb
+++ b/lib/fabrication.rb
@@ -13,7 +13,7 @@ module Fabrication
   module Generator
     autoload :ActiveRecord, 'fabrication/generator/active_record'
     autoload :Mongoid,      'fabrication/generator/mongoid'
-    autoload :Sequel,      'fabrication/generator/sequel'
+    autoload :Sequel,       'fabrication/generator/sequel'
     autoload :Base,         'fabrication/generator/base'
   end
 

--- a/lib/fabrication/schematic.rb
+++ b/lib/fabrication/schematic.rb
@@ -103,6 +103,11 @@ class Fabrication::Schematic
     method_name
   end
 
+  def sequence(name, start=0, &block)
+    name = "#{self.klass.to_s.downcase.gsub(/::/, '_')}_#{name}"
+    Fabrication::Sequencer.sequence(name, start, &block)
+  end
+
   private
 
   def generate_value(name, params)

--- a/spec/fabrication_spec.rb
+++ b/spec/fabrication_spec.rb
@@ -393,4 +393,18 @@ describe Fabrication do
 
   end
 
+  describe "Fabricate with a sequence" do
+    subject { Fabricate(:sequencer) }
+
+    its(:simple_iterator) { should == 0 }
+    its(:param_iterator)  { should == 10 }
+    its(:block_iterator)  { should == "block2" }
+
+    context "when namespaced" do
+      subject { Fabricate("Sequencer::Namespaced") }
+
+      its(:iterator) { should == 0 }
+    end
+  end
+
 end

--- a/spec/fabricators.rb
+++ b/spec/fabricators.rb
@@ -38,6 +38,16 @@ Fabricator("Something::Amazing") do
   stuff "cool"
 end
 
+Fabricator(:sequencer) do
+  simple_iterator { sequence(:simple_iterator) }
+  param_iterator  { sequence(:param_iterator, 9) }
+  block_iterator  { sequence(:block_iterator) { |i| "block#{i}" } }
+end
+
+Fabricator("Sequencer::Namespaced") do
+  iterator { sequence(:iterator) }
+end
+
 # ActiveRecord Objects
 Fabricator(:division) do
   name "Division Name"

--- a/spec/support/helper_objects.rb
+++ b/spec/support/helper_objects.rb
@@ -32,3 +32,11 @@ module Something
     attr_accessor :stuff
   end
 end
+
+class Sequencer
+  attr_accessor :simple_iterator, :param_iterator, :block_iterator
+
+  class Namespaced
+    attr_accessor :iterator
+  end
+end


### PR DESCRIPTION
Hello, Paul. What do you think about making sequences syntax a little bit shorter? I tryed to do a first step, but I couldn't get rid from name argument. Is it possible to get an method_name from which sequence method was executed? Ideally, I think, it should look like:

``` ruby
Fabricate(:person) do
  ssn { sequence(111111111) }
  email { sequence { |i| "user#{i}@example.com" } }
end
```

Hope, you'll like an idea.
