### PR TITLE
Use ruby highlighting in Readme.md

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -103,7 +103,7 @@ That will use the most recently defined "widget" and pass it into the Fabricator
 In more complex cases where you have already created "widgets" and "wockets" and associated them with other objects, to set up an association between the former two:
 
 ```ruby
-   And that wocket belongs to that widget
+And that wocket belongs to that widget
 ```
 
 ### Usage ###


### PR DESCRIPTION
Changed all ruby codes in Readme to use corresponding markdown syntax for highlighting.
