### PR TITLE
Add support for mongoid dynamic fields

### DIFF
--- a/lib/fabrication/generator/mongoid.rb
+++ b/lib/fabrication/generator/mongoid.rb
@@ -1,0 +1,21 @@
+class Fabrication::Generator::Mongoid < Fabrication::Generator::Base
+  def self.supports?(klass)
+    defined?(Mongoid) && klass.ancestors.include?(Mongoid::Document)
+  end
+
+  def assign(method_name, options, raw_value=nil)
+    if options.has_key?(:count)
+      value = (1..options[:count]).map do |i|
+        block_given? ? yield(instance, i) : raw_value
+      end
+    else
+      value = block_given? ? yield(instance) : raw_value
+    end
+
+    if instance.respond_to?("#{method_name}=")
+      instance.send("#{method_name}=", value)
+    else
+      instance[method_name] = value
+    end
+  end
+end

--- a/lib/fabrication/schematic.rb
+++ b/lib/fabrication/schematic.rb
@@ -3,6 +3,7 @@ class Fabrication::Schematic
   GENERATORS = [
     Fabrication::Generator::ActiveRecord,
     Fabrication::Generator::Sequel,
+    Fabrication::Generator::Mongoid,
     Fabrication::Generator::Base
   ]
 

--- a/spec/fabrication/schematic_spec.rb
+++ b/spec/fabrication/schematic_spec.rb
@@ -18,7 +18,7 @@ describe Fabrication::Schematic do
     end
     context "for a mongoid object" do
       it "uses the base generator" do
-        Fabrication::Schematic.new(Author).generator.should == Fabrication::Generator::Base
+        Fabrication::Schematic.new(Author).generator.should == Fabrication::Generator::Mongoid
       end
     end
     context "for a sequel object" do

--- a/spec/fabrication_spec.rb
+++ b/spec/fabrication_spec.rb
@@ -206,6 +206,14 @@ describe Fabrication do
     it 'generates four books' do
       author.books.map(&:title).should == (1..4).map { |i| "book title #{i}" }
     end
+
+    it "sets dynamic fields" do
+      Fabricate(:special_author).mongoid_dynamic_field.should == 50
+    end
+
+    it "sets lazy dynamic fields" do
+      Fabricate(:special_author).lazy_dynamic_field.should == "foo"
+    end
   end
 
   context 'with multiple callbacks' do

--- a/spec/fabricators/mongoid_fabricator.rb
+++ b/spec/fabricators/mongoid_fabricator.rb
@@ -18,6 +18,11 @@ Fabricator(:author) do
   end
 end
 
+Fabricator(:special_author, :from => :author) do
+  mongoid_dynamic_field 50
+  lazy_dynamic_field { "foo" }
+end
+
 Fabricator(:hemingway, :from => :author) do
   name 'Ernest Hemingway'
 end


### PR DESCRIPTION
This patch adds support for Mongoid dynamic fields (`object[:foo] = 'bar'` without any `field` definition for `:foo`). Includes tests for both lazy and non-lazy fabricators
