### PR TITLE
Add optional make/make! syntax

### DIFF
--- a/lib/fabrication/syntax/make.rb
+++ b/lib/fabrication/syntax/make.rb
@@ -1,0 +1,46 @@
+module Fabrication
+  module Syntax
+
+    # Extends Fabrication to provide make/make! class methods, which are
+    # shortcuts for Fabricate.build/Fabricate.
+    #
+    # Usage:
+    #
+    # require 'fabrication/syntax/make'
+    #
+    # User.make(:name => 'Johnny')
+    #
+    #
+    module Make
+
+      def make(overrides = {}, &block)
+        Fabrication::Fabricator.generate(name.underscore.to_sym,
+                                         {:save => false}, overrides,
+                                         &block)
+      end
+
+      def make!(overrides = {}, &block)
+        Fabrication::Fabricator.generate(name.underscore.to_sym,
+                                         {:save => true}, overrides,
+                                         &block)
+      end
+
+    end
+  end
+end
+
+if Object.const_defined?("Sequel")
+  Sequel::Model.extend Fabrication::Syntax::Make
+end
+
+if Object.const_defined?("ActiveRecord")
+  ActiveRecord::Base.extend Fabrication::Syntax::Make
+end
+
+if Object.const_defined?("Mongoid")
+  module Mongoid::Document
+    def self.included(base)
+      base.send :extend, Fabrication::Syntax::Make
+    end
+  end
+end

--- a/spec/fabrication/syntax/make_spec.rb
+++ b/spec/fabrication/syntax/make_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Fabrication::Syntax::Make do
+
+  describe "#make mongoid" do
+
+    it "should return a fabricated object" do
+      Author.make.should be_instance_of Author
+    end
+
+    it "should overwrite options" do
+      Author.make(:name => "N.Rodrigues").name.should eql("N.Rodrigues")
+    end
+
+    it "should work the same as Fabricate.build" do
+      Author.make.should be_new_record
+    end
+
+    it "bang should be the same as Fabricate" do
+      Author.make!.should_not be_new_record
+    end
+
+  end
+
+  describe "#make activerecord" do
+
+    it "should return a fabricated object" do
+      Company.make.should be_instance_of Company
+    end
+
+    it "should work the same as Fabricate.build" do
+      Company.make.should be_new_record
+    end
+
+    it "bang should be the same as Fabricate" do
+      Company.make!.should_not be_new_record
+    end
+
+  end
+
+  describe "#make sequel" do
+
+    it "should return a fabricated object" do
+      ParentSequelModel.make.should be_instance_of ParentSequelModel
+    end
+
+    it "should be the same as Fabricate.build" do
+      ParentSequelModel.make.should eql(Fabricate.build(:parent_sequel_model))
+    end
+
+    it "bang should be the same as Fabricate" do
+      ParentSequelModel.make!.id.should_not be_nil
+    end
+  end
+
+end

--- a/spec/support/mongoid.rb
+++ b/spec/support/mongoid.rb
@@ -1,4 +1,5 @@
 require 'mongoid'
+require 'fabrication/syntax/make'
 
 Mongoid.configure do |config|
   config.allow_dynamic_fields = true


### PR DESCRIPTION
This adds a syntax that's compatible with Object Daddy`s Class.make.
Alias or a simbling file could easily add generate/generate! which is the machinist way.
Or a simple regex. 'make' is shorter ;)
