### PR TITLE
Make fabrication aware of rails engine testing

### DIFF
--- a/lib/fabrication/support.rb
+++ b/lib/fabrication/support.rb
@@ -23,11 +23,29 @@ class Fabrication::Support
     end
 
     def find_definitions
-      path_prefix = defined?(Rails) ? Rails.root : "."
+      path_prefix = defined?(Rails) ? (find_engine_path || Rails.root) : "."
       Fabrication::Config.fabricator_dir.each do |folder|
         Dir.glob(File.join(path_prefix, folder, '**', '*fabricator.rb')).sort.each do |file|
           load file
         end
+      end
+    end
+
+    private
+
+    def find_engine_path
+      match = Rails.root.to_s.match /(.*)\/(spec|test)\/dummy$/
+      if match
+        maybe_engine_path = match[1]
+        if Rails.application.railties.engines.map{|e| e.root.to_s}.delete_if do |e|
+            e != maybe_engine_path
+          end.size == 1
+          maybe_engine_path
+        else
+          nil
+        end
+      else
+        nil
       end
     end
 


### PR DESCRIPTION
If running tests from rails engine root then fabrication searches for fabricators in dummy application root, not engine root. This patch fixes this beheaviour.
