### PR TITLE
Modify directory globbing to allow loading fabricators from files such as fabricators.rb (note: plural)

### DIFF
--- a/lib/fabrication/support.rb
+++ b/lib/fabrication/support.rb
@@ -25,7 +25,7 @@ class Fabrication::Support
     def find_definitions
       path_prefix = defined?(Rails) ? Rails.root : "."
       Fabrication::Config.fabricator_dir.each do |folder|
-        Dir.glob(File.join(path_prefix, folder, '**', '*fabricator.rb*')).sort.each do |file|
+        Dir.glob(File.join(path_prefix, folder, '**', '*fabricator*.rb')).sort.each do |file|
           load file
         end
       end


### PR DESCRIPTION
I really wanted to be able to use only one fabricator file for my small application, so I added the ability to load that file. This fix will also allow loading files such as user_fabricator**s**.rb.

Hope this makes it to the official fabrication repo.
Thanks!

Ps. awesome gem!
