### PR TITLE
Add "aliases" option to Fabricator definition

### DIFF
--- a/lib/fabrication/fabricator.rb
+++ b/lib/fabrication/fabricator.rb
@@ -4,7 +4,12 @@ class Fabrication::Fabricator
 
     def define(name, options={}, &block)
       raise Fabrication::DuplicateFabricatorError, "'#{name}' is already defined" if schematics.include?(name)
-      schematics[name] = schematic_for(name, options, &block)
+      aliases = Array(options.delete(:aliases))
+      schematic = schematics[name] = schematic_for(name, options, &block)
+      Array(aliases).each do |as|
+        schematics[as.to_sym] = schematic
+      end
+      schematic
     end
 
     def generate(name, options={}, overrides={}, &block)

--- a/spec/fabrication/fabricator_spec.rb
+++ b/spec/fabrication/fabricator_spec.rb
@@ -6,8 +6,10 @@ describe Fabrication::Fabricator do
 
   describe ".define" do
 
+    let(:options) { { aliases: ["thing_one", :thing_two] } }
+
     before(:all) do
-      subject.define(:open_struct) do
+      subject.define(:open_struct, options) do
         first_name "Joe"
         last_name { "Schmoe" }
       end
@@ -31,6 +33,13 @@ describe Fabrication::Fabricator do
       subject.schematics[:open_struct].attributes.size.should == 2
     end
 
+    context "with an alias" do
+
+      it "recognizes the aliases" do
+        subject.schematics[:thing_one].should == subject.schematics[:open_struct]
+        subject.schematics[:thing_two].should == subject.schematics[:open_struct]
+      end
+    end
   end
 
   describe ".generate" do


### PR DESCRIPTION
Allows lazy declaration of class aliases, e.g.

```
Fabricator(:user, aliases: [:reader, :blogger]) do
  name "Dave"
end

Fabricator(:blog_post) do
  blogger!
  text
end
```
