### PR TITLE
Fixed module declaration for turnip steps generator.

### DIFF
--- a/lib/rails/generators/fabrication/turnip_steps/turnip_steps_generator.rb
+++ b/lib/rails/generators/fabrication/turnip_steps/turnip_steps_generator.rb
@@ -1,21 +1,23 @@
 require 'rails/generators/base'
 
-module Fabrication::Generators
-  class TurnipStepsGenerator < Rails::Generators::Base
-    argument :step_dir, :type => :string, :default => "spec/acceptance/steps/"
+module Fabrication
+  module Generators
+    class TurnipStepsGenerator < Rails::Generators::Base
+      argument :step_dir, :type => :string, :default => "spec/acceptance/steps/"
 
-    def generate
-      template 'fabrication_steps.rb', turnip_step_directory
-    end
+      def generate
+        template 'fabrication_steps.rb', turnip_step_directory
+      end
 
-    def self.source_root
-      @_fabrication_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'templates'))
-    end
+      def self.source_root
+        @_fabrication_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'templates'))
+      end
 
-    private
+      private
 
-    def turnip_step_directory
-      File.join(step_dir, 'fabrication_steps.rb')
+      def turnip_step_directory
+        File.join(step_dir, 'fabrication_steps.rb')
+      end
     end
   end
 end


### PR DESCRIPTION
The `fabrication:turnip_steps` generator was broken for me.  When I ran it I got:

```
$> rails g fabrication:turnip_steps
[WARNING] Could not load generator "rails/generators/fabrication/turnip_steps/turnip_steps_generator". Error: uninitialized constant Fabrication.
/Users/cboyd/.rbenv/versions/1.9.3-p0-perf/lib/ruby/gems/1.9.1/gems/fabrication-1.3.1/lib/rails/generators/fabrication/turnip_steps/turnip_steps_generator.rb:3:in `<top (required)>'
/Users/cboyd/.rbenv/versions/1.9.3-p0-perf/lib/ruby/gems/1.9.1/gems/railties-3.2.0/lib/rails/generators.rb:298:in `block (2 levels) in lookup'
/Users/cboyd/.rbenv/versions/1.9.3-p0-perf/lib/ruby/gems/1.9.1/gems/railties-3.2.0/lib/rails/generators.rb:294:in `each'
/Users/cboyd/.rbenv/versions/1.9.3-p0-perf/lib/ruby/gems/1.9.1/gems/railties-3.2.0/lib/rails/generators.rb:294:in `block in lookup'
/Users/cboyd/.rbenv/versions/1.9.3-p0-perf/lib/ruby/gems/1.9.1/gems/railties-3.2.0/lib/rails/generators.rb:293:in `each'
/Users/cboyd/.rbenv/versions/1.9.3-p0-perf/lib/ruby/gems/1.9.1/gems/railties-3.2.0/lib/rails/generators.rb:293:in `lookup'
/Users/cboyd/.rbenv/versions/1.9.3-p0-perf/lib/ruby/gems/1.9.1/gems/railties-3.2.0/lib/rails/generators.rb:151:in `find_by_namespace'
/Users/cboyd/.rbenv/versions/1.9.3-p0-perf/lib/ruby/gems/1.9.1/gems/railties-3.2.0/lib/rails/generators.rb:168:in `invoke'
/Users/cboyd/.rbenv/versions/1.9.3-p0-perf/lib/ruby/gems/1.9.1/gems/railties-3.2.0/lib/rails/commands/generate.rb:12:in `<top (required)>'
/Users/cboyd/.rbenv/versions/1.9.3-p0-perf/lib/ruby/gems/1.9.1/gems/railties-3.2.0/lib/rails/commands.rb:29:in `<top (required)>'
script/rails:6:in `require'
script/rails:6:in `<main>'
Could not find generator fabrication:turnip_steps.
```

Splitting the module declaration fixed it.  I suspect I would have the same problem with the cucumber generator since the module there is defined in the same manner, but I'm not using cuke.
