### PR TITLE
Issue with collection on mongoid 1.6.0

### DIFF
--- a/spec/fabricators/mongoid_fabricator.rb
+++ b/spec/fabricators/mongoid_fabricator.rb
@@ -1,5 +1,5 @@
 Fabricator(:parent_mongoid_document) do
-  collection_field(:count => 2, :fabricator => :child_mongoid_document)
+  collection_field(:count => 2) { |parent, i| Fabricate(:child_mongoid_document, :parent_id => parent.id)  }
   dynamic_field { 'dynamic content' }
   nil_field nil
   number_field 5


### PR DESCRIPTION
Looks like latest version of mongoid cares about parent_id on collections.
