### PR TITLE
Memoize both singular and collection objects

### DIFF
--- a/lib/rails/generators/fabrication/cucumber_steps/templates/fabrication_steps.rb
+++ b/lib/rails/generators/fabrication/cucumber_steps/templates/fabrication_steps.rb
@@ -2,7 +2,8 @@ World(FabricationMethods)
 
 def with_ivars(fabricator)
   @they = yield fabricator
-  instance_variable_set("@#{fabricator.model}", @they)
+  instance_variable_set("@#{fabricator.model.pluralize}", @they) unless @they.one?
+  instance_variable_set("@#{fabricator.model}", @they.last)
 end
 
 Given /^(\d+) ([^"]*)$/ do |count, model_name|


### PR DESCRIPTION
Currently the generated fabrication cucumber steps always memoize generated objects with fabricator name, regardless it is one or many objects with this logic: 

instance_variable_set("@#{fabricator.model}", @they)

This has several issues: 
- if  a collection of books is to be fabricated, they would be memoized as @book
- if one book is fabricated (for example using "Given 1 book"), the current code memoizes [ the_book_object ] to @book
