### PR TITLE
Add DataMapper support (save! in datamapper ignores callbacks)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .bundle
 .DS_Store
 pkg
+:memory

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
     activesupport (3.2.1)
       i18n (~> 0.6)
       multi_json (~> 1.0)
+    addressable (2.2.7)
     arel (3.0.0)
     bson (1.6.0)
     bson_ext (1.6.0)
@@ -29,7 +30,24 @@ GEM
       gherkin (~> 2.7.1)
       json (>= 1.4.6)
       term-ansicolor (>= 1.0.6)
+    data_objects (0.10.8)
+      addressable (~> 2.1)
     diff-lcs (1.1.3)
+    dm-active_model (1.2.1)
+      activemodel (~> 3.0)
+      dm-core (~> 1.2.0)
+    dm-core (1.2.0)
+      addressable (~> 2.2.6)
+    dm-do-adapter (1.2.0)
+      data_objects (~> 0.10.6)
+      dm-core (~> 1.2.0)
+    dm-migrations (1.2.0)
+      dm-core (~> 1.2.0)
+    dm-sqlite-adapter (1.2.0)
+      dm-do-adapter (~> 1.2.0)
+      do_sqlite3 (~> 0.10.6)
+    do_sqlite3 (0.10.8)
+      data_objects (= 0.10.8)
     ffaker (1.12.1)
     fuubar (1.0.0)
       rspec (~> 2.0)
@@ -81,6 +99,10 @@ DEPENDENCIES
   activerecord
   bson_ext
   cucumber
+  dm-active_model
+  dm-core
+  dm-migrations
+  dm-sqlite-adapter
   fabrication!
   ffaker
   fuubar

--- a/fabrication.gemspec
+++ b/fabrication.gemspec
@@ -20,6 +20,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency("activerecord")
   s.add_development_dependency("bson_ext")
   s.add_development_dependency("cucumber")
+  s.add_development_dependency("sqlite3")
+  s.add_development_dependency("dm-active_model")
+  s.add_development_dependency("dm-core")
+  s.add_development_dependency("dm-migrations")
+  s.add_development_dependency("dm-sqlite-adapter")
   s.add_development_dependency("turnip", [">= 0.3"])
   s.add_development_dependency("ffaker")
   s.add_development_dependency("fuubar")
@@ -29,7 +34,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec")
   s.add_development_dependency("sequel")
-  s.add_development_dependency("sqlite3")
 
   s.files = Dir.glob("lib/**/*") + %w(LICENSE README.markdown Rakefile)
   s.require_path = 'lib'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -2,6 +2,7 @@ require 'fabrication'
 
 load 'lib/rails/generators/fabrication/cucumber_steps/templates/fabrication_steps.rb'
 load 'spec/support/active_record.rb'
+load 'spec/support/data_mapper.rb'
 load 'spec/support/plain_old_ruby_objects.rb'
 load 'spec/support/mongoid.rb'
 load 'spec/support/sequel.rb'

--- a/lib/fabrication.rb
+++ b/lib/fabrication.rb
@@ -23,6 +23,7 @@ module Fabrication
 
   module Generator
     autoload :ActiveRecord, 'fabrication/generator/active_record'
+    autoload :DataMapper,   'fabrication/generator/data_mapper'
     autoload :Mongoid,      'fabrication/generator/mongoid'
     autoload :Sequel,       'fabrication/generator/sequel'
     autoload :Base,         'fabrication/generator/base'

--- a/lib/fabrication/generator/data_mapper.rb
+++ b/lib/fabrication/generator/data_mapper.rb
@@ -1,0 +1,14 @@
+class Fabrication::Generator::DataMapper < Fabrication::Generator::Base
+
+  class << self
+    def supports?(klass)
+      defined?(DataMapper) && klass.ancestors.include?(DataMapper::Hook)
+    end
+  end
+
+  protected
+
+  def after_generation(options)
+    __instance.save if options[:save] && __instance.respond_to?(:save)
+  end
+end

--- a/lib/fabrication/schematic/definition.rb
+++ b/lib/fabrication/schematic/definition.rb
@@ -2,6 +2,7 @@ class Fabrication::Schematic::Definition
 
   GENERATORS = [
     Fabrication::Generator::ActiveRecord,
+    Fabrication::Generator::DataMapper,
     Fabrication::Generator::Sequel,
     Fabrication::Generator::Mongoid,
     Fabrication::Generator::Base

--- a/spec/fabrication/generator/data_mapper_spec.rb
+++ b/spec/fabrication/generator/data_mapper_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Fabrication::Generator::DataMapper do
+  describe '.supports?' do
+    subject { Fabrication::Generator::DataMapper }
+
+    it 'returns true for datamapper objects' do
+      subject.supports?(Movie).should be_true
+    end
+
+    it 'returns false for non-datamapper objects objects' do
+      subject.supports?(Company).should be_false
+    end
+  end
+end

--- a/spec/fabrication_spec.rb
+++ b/spec/fabrication_spec.rb
@@ -88,6 +88,26 @@ describe Fabrication do
     end
   end
 
+  context 'data_mapper models' do
+    let(:fabricator_name) { :parent_data_mapper_model }
+    let(:collection_field) { :child_data_mapper_models }
+
+    it_should_behave_like 'something fabricatable'
+
+    context 'associations in attributes_for' do
+      let(:parent_model) { Fabricate(:parent_data_mapper_model) }
+      subject do
+        Fabricate.attributes_for(
+          :child_data_mapper_model, parent_data_mapper_model: parent_model
+        )
+      end
+
+      it 'serializes the belongs_to as an id' do
+        should include({ parent_data_mapper_model_id: parent_model.id })
+      end
+    end
+  end
+
   context 'mongoid documents' do
     let(:fabricator_name) { :parent_mongoid_document }
     let(:collection_field) { :referenced_mongoid_documents }

--- a/spec/fabricators/data_mapper_fabricator.rb
+++ b/spec/fabricators/data_mapper_fabricator.rb
@@ -1,0 +1,24 @@
+Fabricator(:parent_data_mapper_model) do
+  dynamic_field { 'dynamic content' }
+  nil_field nil
+  number_field 5
+  string_field 'content'
+end
+
+Fabricator(:parent_data_mapper_model_with_children, from: :parent_data_mapper_model) do
+  child_data_mapper_models(count: 2)
+end
+
+Fabricator(:child_data_mapper_model) do
+  number_field 10
+end
+
+# DataMapper Objects
+Fabricator(:movie) do
+  name "One Night in Paris"
+end
+
+Fabricator(:porn, :from => :movie)
+
+Fabricator(:store)
+Fabricator(:xxx_movies, :from => :store)

--- a/spec/support/data_mapper.rb
+++ b/spec/support/data_mapper.rb
@@ -1,0 +1,54 @@
+require 'dm-active_model'
+require 'dm-core'
+require 'dm-migrations'
+
+# DataMapper::Logger.new($stdout, :debug)
+DataMapper.setup(:default, "sqlite3::memory")
+
+class ParentDataMapperModel
+  include DataMapper::Resource
+
+  property :id, Serial
+  property :before_save_value, Integer
+  property :dynamic_field, String
+  property :nil_field, String
+  property :number_field, Integer
+  property :string_field, String
+
+  has n, :child_data_mapper_models
+
+  before :save do
+    self.before_save_value = 11
+  end
+end
+
+class ChildDataMapperModel
+  include DataMapper::Resource
+
+  property :id, Serial
+  property :number_field, Integer
+
+  belongs_to :parent_data_mapper_model
+end
+
+class Store
+  include DataMapper::Resource
+
+  property :id, Serial
+  property :name, String
+
+  has n, :movies
+
+  attr_accessor :non_field
+end
+
+class Movie
+  include DataMapper::Resource
+
+  property :id, Serial
+  property :name, String
+
+  belongs_to :store
+end
+
+DataMapper.auto_migrate!


### PR DESCRIPTION
Hey,

Thanks for writing fabrication. I use it in all my apps now. I was having some problems in a data mapper project though. The base generator calls save! by default. Bang methods in data mapper bypass callbacks instead of throwing exceptions so none of my callbacks were running when fabricating models. Here's a data mapper generator.

Thanks,

Matt
