### PR TITLE
Add initialize_with block for schematic definition

### DIFF
--- a/lib/fabrication/schematic/definition.rb
+++ b/lib/fabrication/schematic/definition.rb
@@ -109,6 +109,10 @@ class Fabrication::Schematic::Definition
     callbacks[:on_init] = block
   end
 
+  def initialize_with(&block)
+    callbacks[:initialize_with] = block
+  end
+
   def parse_method_name(method_name)
     if method_name.to_s.end_with?("!")
       warn("DEPRECATION WARNING: Using the \"!\" in Fabricators is no longer supported. Please remove all occurrances")

--- a/spec/fabrication/generator/base_spec.rb
+++ b/spec/fabrication/generator/base_spec.rb
@@ -69,6 +69,50 @@ describe Fabrication::Generator::Base do
       end
     end
 
+    context "with initialize_with block" do
+      subject { schematic.fabricate }
+
+      let(:klass) { Struct.new :arg1, :arg2 }
+
+      context "using only raw values" do
+        let(:schematic) do
+          Fabrication::Schematic::Definition.new(klass) do
+            initialize_with { Struct.new(:arg1, :arg2).new(:fixed_value) }
+          end
+        end
+
+        it "saves the return value of the block as instance" do
+          subject.arg1.should == :fixed_value
+          subject.arg2.should == nil
+        end
+      end
+
+      context "using attributes inside block" do
+        let(:schematic) do
+           Fabrication::Schematic::Definition.new(klass) do
+             arg1 10
+             initialize_with { Struct.new(:arg1, :arg2).new(arg1, arg1 + 10) }
+          end
+        end
+
+        context "without override" do
+          it "saves the return value of the block as instance" do
+            subject.arg1.should == 10
+            subject.arg2.should == 20
+          end
+        end
+
+        context "with override" do
+          subject { schematic.fabricate(arg1: 30) }
+          it "saves the return value of the block as instance" do
+            subject.arg1.should == 30
+            subject.arg2.should == 40
+          end
+        end
+
+      end
+    end
+
     context "using an after_create hook" do
       let(:schematic) do
         Fabrication::Schematic::Definition.new(Person) do

--- a/spec/fabrication/schematic/definition_spec.rb
+++ b/spec/fabrication/schematic/definition_spec.rb
@@ -180,6 +180,34 @@ describe Fabrication::Schematic::Definition do
     end
   end
 
+  describe "#initialize_with" do
+    let(:init_block) { lambda {} }
+    let(:init_schematic) do
+      block = init_block
+      Fabrication::Schematic::Definition.new(OpenStruct) do
+        initialize_with &block
+      end
+    end
+
+    it "stores the initialize_with callback" do
+      init_schematic.callbacks[:initialize_with].should == init_block
+    end
+
+    context "with inheritance" do
+      let(:child_block) { lambda {} }
+      let(:child_schematic) do
+        block = child_block
+        init_schematic.merge do
+          initialize_with &block
+        end
+      end
+
+      it "overwrites the initialize_with callback" do
+        child_schematic.callbacks[:initialize_with].should == child_block
+      end
+    end
+  end
+
   describe '#transient' do
     let(:definition) do
       Fabrication::Schematic::Definition.new(OpenStruct) do


### PR DESCRIPTION
Hi. While using your gem I encountered problem - some instances should be generated not by klass.new, but using third-party factory, so I added recognition for block initialize_with, which allows to use custom code for initializing objects instead of calling "new" method. (FYI: this option is available in factory girl, but we switched to your gem for some reasons)

Also add proper fixes to make preset and overriden variables available in initialize_with block. We are already using this (monkeypatched :) ) code in production, hope you will find it usefull to.
