### PR TITLE
make path_prefix configurable

### DIFF
--- a/lib/fabrication/config.rb
+++ b/lib/fabrication/config.rb
@@ -16,6 +16,14 @@ module Fabrication
     end
     alias fabricator_dir= fabricator_path=
 
+    def path_prefix
+      OPTIONS[:path_prefix]
+    end
+
+    def path_prefix=(prefix)
+      OPTIONS[:path_prefix] = prefix
+    end
+
     def reset_defaults
       OPTIONS.replace(DEFAULTS)
     end
@@ -36,7 +44,8 @@ module Fabrication
 
     DEFAULTS = {
       fabricator_path: ['test/fabricators', 'spec/fabricators'],
-      register_with_steps: false
+      register_with_steps: false,
+      path_prefix: defined?(Rails) ? Rails.root : "."
     }
     OPTIONS = {}.merge!(DEFAULTS)
   end

--- a/lib/fabrication/support.rb
+++ b/lib/fabrication/support.rb
@@ -28,9 +28,8 @@ class Fabrication::Support
 
     def find_definitions
       Fabrication.schematics.preinitialize
-      path_prefix = defined?(Rails) ? Rails.root : "."
       Fabrication::Config.fabricator_dir.each do |folder|
-        Dir.glob(File.join(path_prefix, folder, '**', '*.rb')).sort.each do |file|
+        Dir.glob(File.join(Fabrication::Config.path_prefix, folder, '**', '*.rb')).sort.each do |file|
           load file
         end
       end


### PR DESCRIPTION
This path makes the path_prefix configurable so it can be used with Rails engines.

A default path_prefix is provided based on the current logic, so the path_prefix is not an obligatory configuration.

Example:

Fabrication.configure do |config|
  config.fabricator_path = "test/fixtures/fabricators"
  config.path_prefix = MyEngine::Engine.root
end
