### PR TITLE
don't use mass assignment for sequel models

### DIFF
--- a/lib/fabrication/generator/sequel.rb
+++ b/lib/fabrication/generator/sequel.rb
@@ -4,10 +4,6 @@ class Fabrication::Generator::Sequel < Fabrication::Generator::Base
     defined?(Sequel) && klass.ancestors.include?(Sequel::Model)
   end
 
-  def build_instance
-    self.__instance = __klass.new(__attributes)
-  end
-
   def persist
     __instance.save
   end

--- a/spec/support/sequel.rb
+++ b/spec/support/sequel.rb
@@ -17,6 +17,7 @@ end
 
 class ParentSequelModel < Sequel::Model
   one_to_many :child_sequel_models
+  set_restricted_columns :string_field
 
   def persisted?; !new? end
 


### PR DESCRIPTION
Looks like the simplest way to fix issue with mass assignment for Sequel models is not to use mass assignment at all. More about mass assignment in Sequel is here - http://sequel.rubyforge.org/rdoc/files/doc/mass_assignment_rdoc.html

fixes #121

@paulelliott, what do you think? 
