### PR TITLE
Added Sequencer#default_sequence_start

### DIFF
--- a/lib/fabrication.rb
+++ b/lib/fabrication.rb
@@ -62,7 +62,7 @@ class Fabricate
     end
   end
 
-  def self.sequence(name=Fabrication::Sequencer::DEFAULT, start=0, &block)
+  def self.sequence(name=Fabrication::Sequencer::DEFAULT, start=nil, &block)
     Fabrication::Sequencer.sequence(name, start, &block)
   end
 end

--- a/lib/fabrication/schematic/definition.rb
+++ b/lib/fabrication/schematic/definition.rb
@@ -127,7 +127,7 @@ class Fabrication::Schematic::Definition
     end
   end
 
-  def sequence(name=Fabrication::Sequencer::DEFAULT, start=0, &block)
+  def sequence(name=Fabrication::Sequencer::DEFAULT, start=nil, &block)
     name = "#{self.klass.to_s.downcase.gsub(/::/, '_')}_#{name}"
     Fabrication::Sequencer.sequence(name, start, &block)
   end

--- a/lib/fabrication/sequencer.rb
+++ b/lib/fabrication/sequencer.rb
@@ -2,8 +2,12 @@ class Fabrication::Sequencer
 
   DEFAULT = :_default
 
-  def self.sequence(name=DEFAULT, start=0, &block)
-    idx = sequences[name] ||= start
+  def self.default_sequence_start(value)
+    @default_sequence_start = value
+  end
+
+  def self.sequence(name=DEFAULT, start=nil, &block)
+    idx = sequences[name] ||= start || @default_sequence_start || 0
     if block_given?
       sequence_blocks[name] = block.to_proc
     else
@@ -19,5 +23,11 @@ class Fabrication::Sequencer
 
   def self.sequence_blocks
     @sequence_blocks ||= {}
+  end
+
+  def self.reset
+    @sequences = nil
+    @sequence_blocks = nil
+    @default_sequence_start = nil
   end
 end

--- a/spec/fabrication/sequencer_spec.rb
+++ b/spec/fabrication/sequencer_spec.rb
@@ -95,4 +95,23 @@ describe Fabrication::Sequencer do
       Fabricate.sequence(:colors).should == 'green'
     end
   end
+
+  context "with a default sequence start" do
+    before do
+      Fabrication::Sequencer.reset
+      Fabrication::Sequencer.default_sequence_start 10000
+    end
+
+    it "starts a new sequence at the default" do
+      Fabricate.sequence(:default_test).should == 10000
+    end
+
+    it "respects start value passed as an argument" do
+      Fabricate.sequence(:default_test2, 9).should == 9
+    end
+
+    after do
+      Fabrication::Sequencer.reset
+    end
+  end
 end


### PR DESCRIPTION
When using fixture generators like fixture_builder with fabrication, sequence collisions can occur since fixtures will exist having used the sequencer in a past run (so any tests that fabricate the same objects will collide). You can get around this by using different sequence start values between fixture building and tests, and setting it globally like this is by far the most convenient way to do that.
