### PR TITLE
Add support for activerecord 4.

### DIFF
--- a/lib/fabrication.rb
+++ b/lib/fabrication.rb
@@ -21,12 +21,14 @@ module Fabrication
   autoload :Cucumber, 'fabrication/cucumber/step_fabricator'
 
   module Generator
-    autoload :ActiveRecord, 'fabrication/generator/active_record'
-    autoload :DataMapper,   'fabrication/generator/data_mapper'
-    autoload :Mongoid,      'fabrication/generator/mongoid'
-    autoload :Sequel,       'fabrication/generator/sequel'
-    autoload :Keymaker,     'fabrication/generator/keymaker'
-    autoload :Base,         'fabrication/generator/base'
+    autoload :ActiveRecord,  'fabrication/generator/active_record'
+    autoload :ActiveRecord3, 'fabrication/generator/active_record/active_record_3'
+    autoload :ActiveRecord4, 'fabrication/generator/active_record/active_record_4'
+    autoload :DataMapper,    'fabrication/generator/data_mapper'
+    autoload :Mongoid,       'fabrication/generator/mongoid'
+    autoload :Sequel,        'fabrication/generator/sequel'
+    autoload :Keymaker,      'fabrication/generator/keymaker'
+    autoload :Base,          'fabrication/generator/base'
   end
 
   def self.clear_definitions

--- a/lib/fabrication/generator/active_record.rb
+++ b/lib/fabrication/generator/active_record.rb
@@ -4,8 +4,8 @@ class Fabrication::Generator::ActiveRecord < Fabrication::Generator::Base
     defined?(ActiveRecord) && klass.ancestors.include?(ActiveRecord::Base)
   end
 
-  def build_instance
-    self.__instance = __klass.new(__attributes, without_protection: true)
+  private
+  def self.active_record_4?
+    ActiveRecord::VERSION::MAJOR == 4
   end
-
 end

--- a/lib/fabrication/generator/active_record/active_record_3.rb
+++ b/lib/fabrication/generator/active_record/active_record_3.rb
@@ -1,0 +1,10 @@
+class Fabrication::Generator::ActiveRecord3 < Fabrication::Generator::ActiveRecord
+
+  def self.supports?(klass)
+    super && !active_record_4?
+  end
+
+  def build_instance
+    self.__instance = __klass.new(__attributes, without_protection: true)
+  end
+end

--- a/lib/fabrication/generator/active_record/active_record_4.rb
+++ b/lib/fabrication/generator/active_record/active_record_4.rb
@@ -1,0 +1,10 @@
+class Fabrication::Generator::ActiveRecord4 < Fabrication::Generator::ActiveRecord
+
+  def self.supports?(klass)
+    super && active_record_4?
+  end
+
+  def build_instance
+    self.__instance = __klass.new(__attributes)
+  end
+end

--- a/lib/fabrication/schematic/definition.rb
+++ b/lib/fabrication/schematic/definition.rb
@@ -1,7 +1,8 @@
 class Fabrication::Schematic::Definition
 
   GENERATORS = [
-    Fabrication::Generator::ActiveRecord,
+    Fabrication::Generator::ActiveRecord3,
+    Fabrication::Generator::ActiveRecord4,
     Fabrication::Generator::DataMapper,
     Fabrication::Generator::Sequel,
     Fabrication::Generator::Mongoid,


### PR DESCRIPTION
**NOTE:** This is not ready to be pulled in immediately due to the lack of tests. I wanted to get the dialog started, however, since I'm not quite sure how you want to proceed. 

The issue is that the current testing setup doesn't allow for easy testing of different versions of dependencies. For example datamapper & mongoid both require activemodel 3 while activerecord 4 obviously requires the edge version. Side note: Most of the existing specs do pass with the changes I made as well as the relavent activerecord specs when switching the gemspec to version 4.

One possible solution would be to use [Appraisal](https://github.com/thoughtbot/appraisal). This is the current approach used by [factory_girl](https://github.com/thoughtbot/factory_girl/blob/master/Appraisals). 

Also I'm not sure if my implementation is the preferred one. My logic was that there may be further changes down the road where having sperate activerecord modules for different versions would be cleaner, however I may be overcomplicating things.

I realize this isn't priority due to the fact that rails 4 is still in fairly early development, however I figured I would get the ball rolling. I also wanted to hold off on any larger changes until a discussion was had on the preferred methodology.

Thanks! 
