### PR TITLE
Allow opcional params in initialiaze_with

### DIFF
--- a/lib/fabrication/generator/base.rb
+++ b/lib/fabrication/generator/base.rb
@@ -72,6 +72,7 @@ class Fabrication::Generator::Base
   end
 
   def method_missing(method_name, *args, &block)
+    return __attributes[method_name] if __klass.public_instance_methods.include? method_name
     __attributes[method_name] || super
   end
 

--- a/spec/fabrication/generator/base_spec.rb
+++ b/spec/fabrication/generator/base_spec.rb
@@ -91,7 +91,9 @@ describe Fabrication::Generator::Base do
         let(:schematic) do
            Fabrication::Schematic::Definition.new(klass) do
              arg1 10
-             initialize_with { Struct.new(:arg1, :arg2).new(arg1, arg1 + 10) }
+             initialize_with do
+               Struct.new(:arg1, :arg2).new(arg1, arg2 || arg1 + 10)
+             end
           end
         end
 
@@ -109,8 +111,9 @@ describe Fabrication::Generator::Base do
             subject.arg2.should == 40
           end
         end
-
+        
       end
+      
     end
 
     context "using an after_create hook" do


### PR DESCRIPTION
Anything in the class interface show be treated as defined and returning nil, do not raise an NoMethodError. It allow you to call any class method.
