### PR TITLE
Removing protection from mongoid4

### DIFF
--- a/lib/fabrication/generator/mongoid.rb
+++ b/lib/fabrication/generator/mongoid.rb
@@ -5,7 +5,7 @@ class Fabrication::Generator::Mongoid < Fabrication::Generator::Base
   end
 
   def build_instance
-    if Gem::Version.new(Mongoid::VERSION).between?(Gem::Version.new('2.3.0'), Gem::Version.new('4.0.0'))
+    if Gem::Version.new(Mongoid::VERSION) == Gem::Version.new('2.3.0')
       self.__instance = __klass.new(__attributes, without_protection: true)
     else
       self.__instance = __klass.new(__attributes)


### PR DESCRIPTION
This is necessary so the ArgumentError won't happen:
ArgumentError:
       wrong number of arguments (2 for 0..1)
