### PR TITLE
Fix module declaration for cucumber step generator

### DIFF
--- a/lib/rails/generators/fabrication/cucumber_steps/cucumber_steps_generator.rb
+++ b/lib/rails/generators/fabrication/cucumber_steps/cucumber_steps_generator.rb
@@ -1,15 +1,16 @@
 require 'rails/generators/base'
 
-module Fabrication::Generators
-  class CucumberStepsGenerator < Rails::Generators::Base
+module Fabrication
+  module Generators
+    class CucumberStepsGenerator < Rails::Generators::Base
 
-    def generate
-      template 'fabrication_steps.rb', "features/step_definitions/fabrication_steps.rb"
+      def generate
+        template 'fabrication_steps.rb', "features/step_definitions/fabrication_steps.rb"
+      end
+
+      def self.source_root
+        @_fabrication_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'templates'))
+      end
     end
-
-    def self.source_root
-      @_fabrication_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'templates'))
-    end
-
   end
 end


### PR DESCRIPTION
Fixes error message: "[WARNING] Could not load generator "rails/generators/fabrication/cucumber_steps/cucumber_steps_generator". Error: uninitialized constant Fabrication." when running `rails generate fabrication:cucumber_steps` on Ruby 2.0.0p195, Rails 3.2.13, OS X 10.8.4

See also: pull request #88
