### PR TITLE
Override attributes before fabricate block attrs

### DIFF
--- a/lib/fabrication/schematic/definition.rb
+++ b/lib/fabrication/schematic/definition.rb
@@ -23,12 +23,24 @@ class Fabrication::Schematic::Definition
   end
 
   def append_or_update_attribute(attribute_name, value, params={}, &block)
+    add_or_update_attribute(:append, attribute_name, value, params, &block)
+  end
+
+  def prepend_or_update_attribute(attribute_name, value, params={}, &block)
+    add_or_update_attribute(:prepend, attribute_name, value, params, &block)
+  end
+
+  def add_or_update_attribute(add_method, attribute_name, value, params={}, &block)
     attribute = Fabrication::Schematic::Attribute.new(klass, attribute_name, value, params, &block)
     if index = attributes.index { |a| a.name == attribute.name }
       attribute.transient! if attributes[index].transient?
       attributes[index] = attribute
     else
-      attributes << attribute
+      if add_method == :append
+        attributes << attribute
+      elsif add_method == :prepend
+        attributes.unshift(attribute)
+      end
     end
   end
 
@@ -84,7 +96,7 @@ class Fabrication::Schematic::Definition
     clone.tap do |definition|
       definition.process_block(&block)
       overrides.each do |name, value|
-        definition.append_or_update_attribute(name.to_sym, value)
+        definition.prepend_or_update_attribute(name.to_sym, value)
       end
     end
   end

--- a/spec/fabrication/schematic/definition_spec.rb
+++ b/spec/fabrication/schematic/definition_spec.rb
@@ -150,6 +150,41 @@ describe Fabrication::Schematic::Definition do
 
     end
 
+    context 'when overriding' do
+      subject do
+        schematic.merge(:something => 42) do
+          another_thing { |attrs| "#{attrs[:name]} says #{attrs[:something]}" }
+        end
+      end
+
+      it "stored 'name' correctly" do
+        attribute = subject.attribute(:name)
+        attribute.name.should == :name
+        attribute.params.should == {}
+        attribute.value.should == "Orgasmo"
+        # Attributes in Fabricator first
+        subject.attributes[0].name.should == :name
+      end
+
+      it "stored 'something' correctly" do
+        attribute = subject.attribute(:something)
+        attribute.name.should == :something
+        attribute.params.should == {}
+        attribute.value.should == 42
+        # Attributes in override next
+        subject.attributes[1].name.should == :something
+      end
+
+      it "stored 'another_thing' correctly" do
+        attribute = subject.attribute(:another_thing)
+        attribute.name.should == :another_thing
+        attribute.params.should == {}
+        Proc.should === attribute.value
+        # Finally, attributes in Fabricate block last
+        subject.attributes[2].name.should == :another_thing
+      end
+    end
+
   end
 
   describe "#on_init" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -26,10 +26,12 @@ shared_examples 'something fabricatable' do
         placeholder: 'is not invoked'
       ) do
         dynamic_field { 'new dynamic content' }
+        dependent_dynamic_field { |attrs| "#{attrs[:string_field]} is awesome" }
       end
     end
 
     its(:dynamic_field) { should == 'new dynamic content' }
+    its(:dependent_dynamic_field) { should == 'new content is awesome' }
     its(:nil_field) { should be_nil }
     its(:number_field) { should == 10 }
     its(:string_field) { should == 'new content' }

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -18,6 +18,7 @@ class TestMigration < ActiveRecord::Migration
     create_table :parent_active_record_models, :force => true do |t|
       t.column :before_save_value, :integer
       t.column :dynamic_field, :string
+      t.column :dependent_dynamic_field, :string
       t.column :nil_field, :string
       t.column :number_field, :integer
       t.column :string_field, :string

--- a/spec/support/data_mapper.rb
+++ b/spec/support/data_mapper.rb
@@ -9,6 +9,7 @@ class ParentDataMapperModel
   property :id, Serial
   property :before_save_value, Integer
   property :dynamic_field, String
+  property :dependent_dynamic_field, String
   property :nil_field, String
   property :number_field, Integer
   property :string_field, String

--- a/spec/support/mongoid.rb
+++ b/spec/support/mongoid.rb
@@ -11,6 +11,7 @@ class ParentMongoidDocument
 
   field :before_save_value
   field :dynamic_field
+  field :dependent_dynamic_field
   field :nil_field
   field :number_field
   field :string_field

--- a/spec/support/plain_old_ruby_objects.rb
+++ b/spec/support/plain_old_ruby_objects.rb
@@ -13,6 +13,7 @@ class ParentRubyObject < Persistable
   attr_accessor \
     :before_save_value,
     :dynamic_field,
+    :dependent_dynamic_field,
     :nil_field,
     :number_field,
     :string_field,

--- a/spec/support/sequel_migrations/001_create_tables.rb
+++ b/spec/support/sequel_migrations/001_create_tables.rb
@@ -12,6 +12,7 @@ Sequel.migration do
       primary_key :id
       Integer :before_save_value
       String :dynamic_field
+      String :dependent_dynamic_field
       String :nil_field
       Integer :number_field
       String :string_field


### PR DESCRIPTION
This enables using override attributes inside of dynamic attributes in a Fabricate block.

Example:

``` ruby
house = House.new
person = Fabricate(:person, house: house) do
  vehicle { |attrs| Fabricate(:vehicle, house: attrs[:house]) }
end
```
