### PR TITLE
Support multiple path_prefixes via config

### DIFF
--- a/lib/fabrication/config.rb
+++ b/lib/fabrication/config.rb
@@ -33,9 +33,12 @@ module Fabrication
     attr_writer :sequence_start
     def sequence_start; @sequence_start ||= 0 end
 
-    attr_writer :path_prefix
+    def path_prefix=(folders)
+      @path_prefix = (Array.new << folders).flatten
+    end
+
     def path_prefix
-      @path_prefix ||= defined?(Rails) ? Rails.root : "."
+      @path_prefix ||= [defined?(Rails) ? Rails.root : "."]
     end
 
     attr_writer :register_with_steps

--- a/lib/fabrication/support.rb
+++ b/lib/fabrication/support.rb
@@ -28,9 +28,11 @@ class Fabrication::Support
 
     def find_definitions
       Fabrication.manager.preinitialize
-      Fabrication::Config.fabricator_path.each do |folder|
-        Dir.glob(File.join(Fabrication::Config.path_prefix, folder, '**', '*.rb')).sort.each do |file|
-          load file
+      Fabrication::Config.path_prefix.each do |prefix|
+        Fabrication::Config.fabricator_path.each do |folder|
+          Dir.glob(File.join(prefix, folder, '**', '*.rb')).sort.each do |file|
+            load file
+          end
         end
       end
     rescue Exception => e

--- a/spec/fabrication/config_spec.rb
+++ b/spec/fabrication/config_spec.rb
@@ -6,6 +6,7 @@ describe Fabrication::Config do
 
   context "default configs" do
     its(:fabricator_path) { should == ['test/fabricators', 'spec/fabricators'] }
+    its(:path_prefix) { should == ['.'] }
     its(:sequence_start) { should == 0 }
   end
 
@@ -28,6 +29,28 @@ describe Fabrication::Config do
       end
 
       its(:fabricator_path) { should == ['lib', 'support'] }
+    end
+  end
+
+  describe ".path_prefix" do
+    context "with a single folder" do
+      before do
+        Fabrication.configure do |config|
+          config.path_prefix = '/path/to/app'
+        end
+      end
+
+      its(:path_prefix) { should == ['/path/to/app'] }
+    end
+
+    context "with multiple folders" do
+      before do
+        Fabrication.configure do |config|
+          config.path_prefix = %w(/path/to/app /path/to/gem/fabricators)
+        end
+      end
+
+      its(:path_prefix) { should == ['/path/to/app', '/path/to/gem/fabricators'] }
     end
   end
 end


### PR DESCRIPTION
I ran into a situation where I needed multiple full paths for a project.  I'm not sure if this would be a very common case, but I think it makes sense to support multiple path prefixes along w/ multiple fabricator paths.
