### PR TITLE
Support use of protected_attributes in Rails 4...

### DIFF
--- a/lib/fabrication/generator/active_record.rb
+++ b/lib/fabrication/generator/active_record.rb
@@ -5,7 +5,7 @@ class Fabrication::Generator::ActiveRecord < Fabrication::Generator::Base
   end
 
   def build_instance
-    if _klass.respond_to?(:attr_accessible)
+    if _klass.respond_to?(:protected_attributes)
       self._instance = _klass.new(_attributes, without_protection: true)
     else
       self._instance = _klass.new(_attributes)

--- a/lib/fabrication/generator/mongoid.rb
+++ b/lib/fabrication/generator/mongoid.rb
@@ -5,7 +5,7 @@ class Fabrication::Generator::Mongoid < Fabrication::Generator::Base
   end
 
   def build_instance
-    if _klass.respond_to?(:attr_accessible)
+    if _klass.respond_to?(:protected_attributes)
       self._instance = _klass.new(_attributes, without_protection: true)
     else
       self._instance = _klass.new(_attributes)


### PR DESCRIPTION
... by checking if the class being fabricated has a protected_attributes method instead of using the ActiveRecord version to determine whether protected_attributes is in use.  This supports applications that are being upgrading to Rails 4 but which choose to continue using protected_attributes (via the protected_attributes gem) rather than switching to strong parameters. I tested this with ActiveRecord and it seems to work well, but I didn't get to try it with Mongoid.
