### PR TITLE
Convert specs to RSpec 2.14.8 syntax with Transpec

### DIFF
--- a/spec/fabrication/cucumber/step_fabricator_spec.rb
+++ b/spec/fabrication/cucumber/step_fabricator_spec.rb
@@ -9,7 +9,7 @@ describe Fabrication::Cucumber::StepFabricator do
       let(:fabricator_name) { :dog }
 
       before do
-        Fabricate.stub(:schematic).with(fabricator_name).and_return(double(klass: "Boom"))
+        allow(Fabricate).to receive(:schematic).with(fabricator_name).and_return(double(klass: "Boom"))
       end
 
       it { should == "Boom" }
@@ -33,12 +33,12 @@ describe Fabrication::Cucumber::StepFabricator do
     let(:fabricator) { Fabrication::Cucumber::StepFabricator.new(name) }
 
     it "fabricates n times" do
-      Fabricate.should_receive(:create).with(:dog, {}).exactly(n).times
+      expect(Fabricate).to receive(:create).with(:dog, {}).exactly(n).times
       fabricator.n n
     end
 
     it "fabricates with attrs" do
-      Fabricate.should_receive(:create).
+      expect(Fabricate).to receive(:create).
         with(:dog, :collar => 'red').at_least(1)
       fabricator.n n, :collar => 'red'
     end
@@ -46,18 +46,18 @@ describe Fabrication::Cucumber::StepFabricator do
     context 'with a plural subject' do
       let(:name) { 'dogs' }
       it 'remembers' do
-        Fabricate.stub(:create).and_return("dog1", "dog2", "dog3")
+        allow(Fabricate).to receive(:create).and_return("dog1", "dog2", "dog3")
         fabricator.n n
-        Fabrication::Cucumber::Fabrications[name].should == ["dog1", "dog2", "dog3"]
+        expect(Fabrication::Cucumber::Fabrications[name]).to eq(["dog1", "dog2", "dog3"])
       end
     end
 
     context 'with a singular subject' do
       let(:name) { 'dog' }
       it 'remembers' do
-        Fabricate.stub(:create).and_return("dog1")
+        allow(Fabricate).to receive(:create).and_return("dog1")
         fabricator.n 1
-        Fabrication::Cucumber::Fabrications[name].should == 'dog1'
+        expect(Fabrication::Cucumber::Fabrications[name]).to eq('dog1')
       end
     end
 
@@ -66,16 +66,16 @@ describe Fabrication::Cucumber::StepFabricator do
   describe '#from_table' do
     it 'maps column names to attribute names' do
       table = double(hashes: [{ 'Favorite Color' => 'pink' }])
-      Fabricate.should_receive(:create).with(:bear, :favorite_color => 'pink')
+      expect(Fabricate).to receive(:create).with(:bear, :favorite_color => 'pink')
       Fabrication::Cucumber::StepFabricator.new('bears').from_table(table)
     end
 
     context 'with table transforms' do
       let(:table) { double(hashes: [{ 'some' => 'thing' }]) }
-      before { Fabricate.stub(:create) }
+      before { allow(Fabricate).to receive(:create) }
 
       it 'applies transforms' do
-        Fabrication::Transform.should_receive(:apply_to).
+        expect(Fabrication::Transform).to receive(:apply_to).
           with('bears', {:some => 'thing'}).and_return({})
         Fabrication::Cucumber::StepFabricator.new('bears').from_table(table)
       end
@@ -88,14 +88,14 @@ describe Fabrication::Cucumber::StepFabricator do
          {'some' => 'panother'}]
       end
       it 'fabricates with each rows attributes' do
-        Fabricate.should_receive(:create).with(:dog, {:some => 'thing'})
-        Fabricate.should_receive(:create).with(:dog, {:some => 'panother'})
+        expect(Fabricate).to receive(:create).with(:dog, {:some => 'thing'})
+        expect(Fabricate).to receive(:create).with(:dog, {:some => 'panother'})
         Fabrication::Cucumber::StepFabricator.new(name).from_table(table)
       end
       it 'remembers' do
-        Fabricate.stub(:create).and_return('dog1', 'dog2')
+        allow(Fabricate).to receive(:create).and_return('dog1', 'dog2')
         Fabrication::Cucumber::StepFabricator.new(name).from_table(table)
-        Fabrication::Cucumber::Fabrications[name].should == ["dog1", "dog2"]
+        expect(Fabrication::Cucumber::Fabrications[name]).to eq(["dog1", "dog2"])
       end
     end
 
@@ -106,13 +106,13 @@ describe Fabrication::Cucumber::StepFabricator do
         {'some' => 'thing'}
       end
       it 'fabricates with each row as an attribute' do
-        Fabricate.should_receive(:create).with(:dog, {:some => 'thing'})
+        expect(Fabricate).to receive(:create).with(:dog, {:some => 'thing'})
         Fabrication::Cucumber::StepFabricator.new(name).from_table(table)
       end
       it 'remembers' do
-        Fabricate.stub(:create).and_return('dog1')
+        allow(Fabricate).to receive(:create).and_return('dog1')
         Fabrication::Cucumber::StepFabricator.new(name).from_table(table)
-        Fabrication::Cucumber::Fabrications[name].should == "dog1"
+        expect(Fabrication::Cucumber::Fabrications[name]).to eq("dog1")
       end
     end
   end

--- a/spec/fabrication/generator/active_record_spec.rb
+++ b/spec/fabrication/generator/active_record_spec.rb
@@ -6,11 +6,11 @@ describe Fabrication::Generator::ActiveRecord, depends_on: :active_record do
     subject { Fabrication::Generator::ActiveRecord }
 
     it "returns true for active record objects" do
-      subject.supports?(ParentActiveRecordModel).should be_true
+      expect(subject.supports?(ParentActiveRecordModel)).to be_true
     end
 
     it "returns false for non-active record objects" do
-      subject.supports?(ParentRubyObject).should be_false
+      expect(subject.supports?(ParentRubyObject)).to be_false
     end
   end
 
@@ -21,7 +21,7 @@ describe Fabrication::Generator::ActiveRecord, depends_on: :active_record do
     before { generator.send(:_instance=, instance) }
 
     it "saves" do
-      instance.should_receive(:save!)
+      expect(instance).to receive(:save!)
       generator.send(:persist)
     end
   end

--- a/spec/fabrication/generator/base_spec.rb
+++ b/spec/fabrication/generator/base_spec.rb
@@ -5,7 +5,7 @@ describe Fabrication::Generator::Base do
   describe ".supports?" do
     subject { Fabrication::Generator::Base }
     it "supports any object" do
-      subject.supports?(Object).should be_true
+      expect(subject.supports?(Object)).to be_true
     end
   end
 
@@ -47,8 +47,8 @@ describe Fabrication::Generator::Base do
         end
 
         it "sends the return value of the block to the klass' initialize method" do
-          subject.arg1.should == :a
-          subject.arg2.should == :b
+          expect(subject.arg1).to eq(:a)
+          expect(subject.arg2).to eq(:b)
         end
       end
 
@@ -60,8 +60,8 @@ describe Fabrication::Generator::Base do
         end
 
         it "sends the return value of the block to the klass' initialize method" do
-          subject.arg1.should == :a
-          subject.arg2.should == :b
+          expect(subject.arg1).to eq(:a)
+          expect(subject.arg2).to eq(:b)
         end
 
       end
@@ -80,8 +80,8 @@ describe Fabrication::Generator::Base do
         end
 
         it "saves the return value of the block as instance" do
-          subject.arg1.should == :fixed_value
-          subject.arg2.should == nil
+          expect(subject.arg1).to eq(:fixed_value)
+          expect(subject.arg2).to eq(nil)
         end
       end
 
@@ -95,16 +95,16 @@ describe Fabrication::Generator::Base do
 
         context "without override" do
           it "saves the return value of the block as instance" do
-            subject.arg1.should == 10
-            subject.arg2.should == 20
+            expect(subject.arg1).to eq(10)
+            expect(subject.arg2).to eq(20)
           end
         end
 
         context "with override" do
           subject { schematic.fabricate(arg1: 30) }
           it "saves the return value of the block as instance" do
-            subject.arg1.should == 30
-            subject.arg2.should == 40
+            expect(subject.arg1).to eq(30)
+            expect(subject.arg2).to eq(40)
           end
         end
 
@@ -168,7 +168,7 @@ describe Fabrication::Generator::Base do
     before { generator.send(:_instance=, instance) }
 
     it 'saves' do
-      instance.should_receive(:save!)
+      expect(instance).to receive(:save!)
       generator.send(:persist)
     end
   end

--- a/spec/fabrication/generator/data_mapper_spec.rb
+++ b/spec/fabrication/generator/data_mapper_spec.rb
@@ -5,11 +5,11 @@ describe Fabrication::Generator::DataMapper, depends_on: :data_mapper do
     subject { Fabrication::Generator::DataMapper }
 
     it 'returns true for datamapper objects' do
-      subject.supports?(ParentDataMapperModel).should be_true
+      expect(subject.supports?(ParentDataMapperModel)).to be_true
     end
 
     it 'returns false for non-datamapper objects objects' do
-      subject.supports?(ParentRubyObject).should be_false
+      expect(subject.supports?(ParentRubyObject)).to be_false
     end
   end
 end

--- a/spec/fabrication/schematic/attribute_spec.rb
+++ b/spec/fabrication/schematic/attribute_spec.rb
@@ -21,7 +21,7 @@ describe Fabrication::Schematic::Attribute do
       end
 
       it "has a proc for a value" do
-        Proc.should === subject.value
+        expect(Proc).to be === subject.value
       end
     end
 
@@ -66,7 +66,7 @@ describe Fabrication::Schematic::Attribute do
       end
 
       it 'returns random number of items in collection with a max of passed in value' do
-        (1..random_amount).should be_member(attribute.processed_value({}).length)
+        expect(1..random_amount).to be_member(attribute.processed_value({}).length)
       end
     end
   end

--- a/spec/fabrication/schematic/definition_spec.rb
+++ b/spec/fabrication/schematic/definition_spec.rb
@@ -31,36 +31,36 @@ describe Fabrication::Schematic::Definition do
 
   describe ".new" do
     it "stores the klass" do
-      schematic.klass.should == OpenStruct
+      expect(schematic.klass).to eq(OpenStruct)
     end
     it "stores the generator" do
-      schematic.generator.should == Fabrication::Generator::Base
+      expect(schematic.generator).to eq(Fabrication::Generator::Base)
     end
     it "stores the attributes" do
-      schematic.attributes.size.should == 3
+      expect(schematic.attributes.size).to eq(3)
     end
   end
 
   describe "#attribute" do
     it "returns the requested attribute if it exists" do
-      schematic.attribute(:name).name.should == :name
+      expect(schematic.attribute(:name).name).to eq(:name)
     end
     it "returns nil if it does not exist" do
-      schematic.attribute(:not_there).should be_nil
+      expect(schematic.attribute(:not_there)).to be_nil
     end
   end
 
   describe "#attributes" do
     it "always returns an empty array" do
       schematic.attributes = nil
-      schematic.attributes.should == []
+      expect(schematic.attributes).to eq([])
     end
   end
 
   describe "#fabricate" do
     context "an instance" do
       it "generates a new instance" do
-        schematic.fabricate.should be_kind_of(OpenStruct)
+        expect(schematic.fabricate).to be_kind_of(OpenStruct)
       end
     end
   end
@@ -69,14 +69,14 @@ describe Fabrication::Schematic::Definition do
     let(:hash) { schematic.to_attributes }
 
     it "generates a hash with the object's attributes" do
-      hash.should be_kind_of(Hash)
+      expect(hash).to be_kind_of(Hash)
     end
 
     it "has the correct attributes" do
-      hash.size.should == 3
-      hash[:name].should == 'Orgasmo'
-      hash[:something].should == "hi!"
-      hash[:another_thing].should == 25
+      expect(hash.size).to eq(3)
+      expect(hash[:name]).to eq('Orgasmo')
+      expect(hash[:something]).to eq("hi!")
+      expect(hash[:another_thing]).to eq(25)
     end
   end
 
@@ -90,25 +90,25 @@ describe Fabrication::Schematic::Definition do
 
       it "stored 'name' correctly" do
         attribute = subject.attribute(:name)
-        attribute.name.should == :name
-        attribute.params.should == {}
-        attribute.value.should == "Orgasmo"
+        expect(attribute.name).to eq(:name)
+        expect(attribute.params).to eq({})
+        expect(attribute.value).to eq("Orgasmo")
       end
 
       it "stored 'something' correctly" do
         attribute = subject.attribute(:something)
-        attribute.name.should == :something
-        attribute.params.should == { :param => 2 }
-        Proc.should === attribute.value
-        attribute.value.call.should == "hi!"
+        expect(attribute.name).to eq(:something)
+        expect(attribute.params).to eq({ :param => 2 })
+        expect(Proc).to be === attribute.value
+        expect(attribute.value.call).to eq("hi!")
       end
 
       it "stored 'another_thing' correctly" do
         attribute = subject.attribute(:another_thing)
-        attribute.name.should == :another_thing
-        attribute.params.should == {}
-        Proc.should === attribute.value
-        attribute.value.call.should == 25
+        expect(attribute.name).to eq(:another_thing)
+        expect(attribute.params).to eq({})
+        expect(Proc).to be === attribute.value
+        expect(attribute.value.call).to eq(25)
       end
 
     end
@@ -127,25 +127,25 @@ describe Fabrication::Schematic::Definition do
 
       it "stored 'name' correctly" do
         attribute = subject.attribute(:name)
-        attribute.name.should == :name
-        attribute.params.should == {}
-        Proc.should === attribute.value
-        attribute.value.call.should == "Willis"
+        expect(attribute.name).to eq(:name)
+        expect(attribute.params).to eq({})
+        expect(Proc).to be === attribute.value
+        expect(attribute.value.call).to eq("Willis")
       end
 
       it "stored 'something' correctly" do
         attribute = subject.attribute(:something)
-        attribute.name.should == :something
-        attribute.params.should == {}
-        attribute.value.should == "Else!"
+        expect(attribute.name).to eq(:something)
+        expect(attribute.params).to eq({})
+        expect(attribute.value).to eq("Else!")
       end
 
       it "stored 'another_thing' correctly" do
         attribute = subject.attribute(:another_thing)
-        attribute.name.should == :another_thing
-        attribute.params.should == { :thats_what => 'she_said' }
-        Proc.should === attribute.value
-        attribute.value.call.should == "Boo-ya!"
+        expect(attribute.name).to eq(:another_thing)
+        expect(attribute.params).to eq({ :thats_what => 'she_said' })
+        expect(Proc).to be === attribute.value
+        expect(attribute.value.call).to eq("Boo-ya!")
       end
 
     end
@@ -162,7 +162,7 @@ describe Fabrication::Schematic::Definition do
     end
 
     it "stores the on_init callback" do
-      init_schematic.callbacks[:on_init].should == init_block
+      expect(init_schematic.callbacks[:on_init]).to eq(init_block)
     end
 
     context "with inheritance" do
@@ -175,7 +175,7 @@ describe Fabrication::Schematic::Definition do
       end
 
       it "overwrites the on_init callback" do
-        child_schematic.callbacks[:on_init].should == child_block
+        expect(child_schematic.callbacks[:on_init]).to eq(child_block)
       end
     end
   end
@@ -190,7 +190,7 @@ describe Fabrication::Schematic::Definition do
     end
 
     it "stores the initialize_with callback" do
-      init_schematic.callbacks[:initialize_with].should == init_block
+      expect(init_schematic.callbacks[:initialize_with]).to eq(init_block)
     end
 
     context "with inheritance" do
@@ -203,7 +203,7 @@ describe Fabrication::Schematic::Definition do
       end
 
       it "overwrites the initialize_with callback" do
-        child_schematic.callbacks[:initialize_with].should == child_block
+        expect(child_schematic.callbacks[:initialize_with]).to eq(child_block)
       end
     end
   end
@@ -216,14 +216,14 @@ describe Fabrication::Schematic::Definition do
     end
 
     it 'stores the attributes as transient' do
-      definition.attributes.map(&:transient?).should == [true, true, true]
+      expect(definition.attributes.map(&:transient?)).to eq([true, true, true])
     end
 
     it "accept default value" do
-      definition.attributes[1].name.should == :two
-      definition.attributes[1].value.should == 'with a default value'
-      definition.attributes[2].name.should == :three
-      definition.attributes[2].value.should == 200
+      expect(definition.attributes[1].name).to eq(:two)
+      expect(definition.attributes[1].value).to eq('with a default value')
+      expect(definition.attributes[2].name).to eq(:three)
+      expect(definition.attributes[2].value).to eq(200)
     end
   end
 

--- a/spec/fabrication/schematic/evaluator_spec.rb
+++ b/spec/fabrication/schematic/evaluator_spec.rb
@@ -16,7 +16,7 @@ describe Fabrication::Schematic::Evaluator do
       end
       its(:name) { should == :dynamic_field }
       it 'the attribute produces the correct value' do
-        subject.processed_value({}).should be_kind_of(ChildRubyObject)
+        expect(subject.processed_value({})).to be_kind_of(ChildRubyObject)
       end
     end
 
@@ -28,7 +28,7 @@ describe Fabrication::Schematic::Evaluator do
       end
       its(:name) { should == :dynamic_field }
       it 'the attribute produces the correct value' do
-        subject.processed_value({}).first.should be_kind_of(ChildRubyObject)
+        expect(subject.processed_value({}).first).to be_kind_of(ChildRubyObject)
       end
     end
   end

--- a/spec/fabrication/schematic/manager_spec.rb
+++ b/spec/fabrication/schematic/manager_spec.rb
@@ -18,21 +18,21 @@ describe Fabrication::Schematic::Manager do
     end
 
     it "creates a schematic" do
-      subject.schematics[:open_struct].should be
+      expect(subject.schematics[:open_struct]).to be
     end
 
     it "has the correct class" do
-      subject.schematics[:open_struct].klass.should == OpenStruct
+      expect(subject.schematics[:open_struct].klass).to eq(OpenStruct)
     end
 
     it "has the attributes" do
-      subject.schematics[:open_struct].attributes.size.should == 2
+      expect(subject.schematics[:open_struct].attributes.size).to eq(2)
     end
 
     context "with an alias" do
       it "recognizes the aliases" do
-        subject.schematics[:thing_one].should == subject.schematics[:open_struct]
-        subject.schematics[:thing_two].should == subject.schematics[:open_struct]
+        expect(subject.schematics[:thing_one]).to eq(subject.schematics[:open_struct])
+        expect(subject.schematics[:thing_two]).to eq(subject.schematics[:open_struct])
       end
     end
 
@@ -67,7 +67,7 @@ describe Fabrication::Schematic::Manager do
     context 'happy path' do
       it "loaded definitions" do
         Fabrication.manager.load_definitions
-        Fabrication.manager[:parent_ruby_object].should be
+        expect(Fabrication.manager[:parent_ruby_object]).to be
       end
     end
 
@@ -75,7 +75,7 @@ describe Fabrication::Schematic::Manager do
       it 'still freezes the manager' do
         expect(Fabrication::Config).to receive(:fabricator_paths).and_raise(Exception)
         expect { Fabrication.manager.load_definitions }.to raise_error
-        Fabrication.manager.should_not be_initializing
+        expect(Fabrication.manager).not_to be_initializing
       end
     end
   end

--- a/spec/fabrication/sequencer_spec.rb
+++ b/spec/fabrication/sequencer_spec.rb
@@ -7,28 +7,28 @@ describe Fabrication::Sequencer do
 
     it { should == 0 }
     it 'creates a default sequencer' do
-      Fabrication::Sequencer.sequences[:_default].should == 1
+      expect(Fabrication::Sequencer.sequences[:_default]).to eq(1)
     end
   end
 
   context 'with only a name' do
 
     it 'starts with 0' do
-      Fabricate.sequence(:incr).should == 0
+      expect(Fabricate.sequence(:incr)).to eq(0)
     end
 
     it 'increments by one with each call' do
-      Fabricate.sequence(:incr).should == 1
-      Fabricate.sequence(:incr).should == 2
-      Fabricate.sequence(:incr).should == 3
-      Fabricate.sequence(:incr).should == 4
+      expect(Fabricate.sequence(:incr)).to eq(1)
+      expect(Fabricate.sequence(:incr)).to eq(2)
+      expect(Fabricate.sequence(:incr)).to eq(3)
+      expect(Fabricate.sequence(:incr)).to eq(4)
     end
 
     it 'increments counters separately' do
-      Fabricate.sequence(:number).should == 0
-      Fabricate.sequence(:number).should == 1
-      Fabricate.sequence(:number).should == 2
-      Fabricate.sequence(:number).should == 3
+      expect(Fabricate.sequence(:number)).to eq(0)
+      expect(Fabricate.sequence(:number)).to eq(1)
+      expect(Fabricate.sequence(:number)).to eq(2)
+      expect(Fabricate.sequence(:number)).to eq(3)
     end
 
   end
@@ -36,14 +36,14 @@ describe Fabrication::Sequencer do
   context 'with a name and starting number' do
 
     it 'starts with the number provided' do
-      Fabricate.sequence(:higher, 69).should == 69
+      expect(Fabricate.sequence(:higher, 69)).to eq(69)
     end
 
     it 'increments by one with each call' do
-      Fabricate.sequence(:higher).should == 70
-      Fabricate.sequence(:higher, 69).should == 71
-      Fabricate.sequence(:higher).should == 72
-      Fabricate.sequence(:higher).should == 73
+      expect(Fabricate.sequence(:higher)).to eq(70)
+      expect(Fabricate.sequence(:higher, 69)).to eq(71)
+      expect(Fabricate.sequence(:higher)).to eq(72)
+      expect(Fabricate.sequence(:higher)).to eq(73)
     end
 
   end
@@ -51,19 +51,19 @@ describe Fabrication::Sequencer do
   context 'with a block' do
 
     it 'yields the number to the block and returns the value' do
-      Fabricate.sequence(:email) do |i|
+      expect(Fabricate.sequence(:email) do |i|
         "user#{i}@example.com"
-      end.should == "user0@example.com"
+      end).to eq("user0@example.com")
     end
 
     it 'increments by one with each call' do
-      Fabricate.sequence(:email) do |i|
+      expect(Fabricate.sequence(:email) do |i|
         "user#{i}@example.com"
-      end.should == "user1@example.com"
+      end).to eq("user1@example.com")
 
-      Fabricate.sequence(:email) do |i|
+      expect(Fabricate.sequence(:email) do |i|
         "user#{i}@example.com"
-      end.should == "user2@example.com"
+      end).to eq("user2@example.com")
     end
 
     context 'and then without a block' do
@@ -71,14 +71,14 @@ describe Fabrication::Sequencer do
         Fabricate.sequence :changing_blocks do |i|
           i * 10
         end
-        Fabricate.sequence(:changing_blocks).should == 10
+        expect(Fabricate.sequence(:changing_blocks)).to eq(10)
       end
       context 'and then with a new block' do
         it 'evaluates the new block' do
-          Fabricate.sequence(:changing_blocks) { |i| i ** 2 }.should == 4
+          expect(Fabricate.sequence(:changing_blocks) { |i| i ** 2 }).to eq(4)
         end
         it 'remembers the new block' do
-          Fabricate.sequence(:changing_blocks).should == 9
+          expect(Fabricate.sequence(:changing_blocks)).to eq(9)
         end
       end
     end
@@ -91,8 +91,8 @@ describe Fabrication::Sequencer do
       Fabricate.sequence(:colors) do |i|
         %w[red green blue][i % 3]
       end
-      Fabricate.sequence(:shapes).should == 'circle'
-      Fabricate.sequence(:colors).should == 'green'
+      expect(Fabricate.sequence(:shapes)).to eq('circle')
+      expect(Fabricate.sequence(:colors)).to eq('green')
     end
   end
 
@@ -103,11 +103,11 @@ describe Fabrication::Sequencer do
     end
 
     it "starts a new sequence at the default" do
-      Fabricate.sequence(:default_test).should == 10000
+      expect(Fabricate.sequence(:default_test)).to eq(10000)
     end
 
     it "respects start value passed as an argument" do
-      Fabricate.sequence(:default_test2, 9).should == 9
+      expect(Fabricate.sequence(:default_test2, 9)).to eq(9)
     end
 
     after do

--- a/spec/fabrication/support_spec.rb
+++ b/spec/fabrication/support_spec.rb
@@ -7,15 +7,15 @@ describe Fabrication::Support do
     context "with a class that exists" do
 
       it "returns the class for a class" do
-        Fabrication::Support.class_for(Object).should == Object
+        expect(Fabrication::Support.class_for(Object)).to eq(Object)
       end
 
       it "returns the class for a class name string" do
-        Fabrication::Support.class_for('object').should == Object
+        expect(Fabrication::Support.class_for('object')).to eq(Object)
       end
 
       it "returns the class for a class name symbol" do
-        Fabrication::Support.class_for(:object).should == Object
+        expect(Fabrication::Support.class_for(:object)).to eq(Object)
       end
 
     end
@@ -23,13 +23,13 @@ describe Fabrication::Support do
     context "with a class that doesn't exist" do
 
       it "returns nil for a class name string" do
-        lambda { Fabrication::Support.class_for('your_mom') }.
-          should raise_error(Fabrication::UnfabricatableError)
+        expect { Fabrication::Support.class_for('your_mom') }.
+          to raise_error(Fabrication::UnfabricatableError)
       end
 
       it "returns nil for a class name symbol" do
-        lambda { Fabrication::Support.class_for(:your_mom) }.
-          should raise_error(Fabrication::UnfabricatableError)
+        expect { Fabrication::Support.class_for(:your_mom) }.
+          to raise_error(Fabrication::UnfabricatableError)
       end
 
       context "and custom const_missing is defined" do
@@ -42,8 +42,8 @@ describe Fabrication::Support do
         end
 
         it "raises an exception with the message from the original exception" do
-          lambda { Fabrication::Support.class_for("Family::Mom") }.
-            should raise_error(Fabrication::UnfabricatableError, /original message/)
+          expect { Fabrication::Support.class_for("Family::Mom") }.
+            to raise_error(Fabrication::UnfabricatableError, /original message/)
         end
       end
     end

--- a/spec/fabrication/syntax/make_spec.rb
+++ b/spec/fabrication/syntax/make_spec.rb
@@ -5,54 +5,54 @@ describe Fabrication::Syntax::Make do
 
   describe "#make mongoid", depends_on: :mongoid do
     it "should return a fabricated object" do
-      ParentMongoidDocument.make.should be_instance_of ParentMongoidDocument
+      expect(ParentMongoidDocument.make).to be_instance_of ParentMongoidDocument
     end
 
     it "should overwrite options" do
-      ParentMongoidDocument.make(string_field: "N.Rodrigues").string_field.should eql("N.Rodrigues")
+      expect(ParentMongoidDocument.make(string_field: "N.Rodrigues").string_field).to eql("N.Rodrigues")
     end
 
     it "should treat a first non-hash argument as fabrication name suffix" do
       Fabricator(:parent_mongoid_document_with_handle, from: :parent_mongoid_document)
-      ParentMongoidDocument.make(:with_handle).string_field.should eql("content")
+      expect(ParentMongoidDocument.make(:with_handle).string_field).to eql("content")
     end
 
     it "should work the same as Fabricate.build" do
-      ParentMongoidDocument.make.should be_new_record
+      expect(ParentMongoidDocument.make).to be_new_record
     end
 
     it "bang should be the same as Fabricate" do
-      ParentMongoidDocument.make!.should_not be_new_record
+      expect(ParentMongoidDocument.make!).not_to be_new_record
     end
   end
 
   describe "#make activerecord", depends_on: :active_record do
 
     it "should return a fabricated object" do
-      ParentActiveRecordModel.make.should be_instance_of ParentActiveRecordModel
+      expect(ParentActiveRecordModel.make).to be_instance_of ParentActiveRecordModel
     end
 
     it "should work the same as Fabricate.build" do
-      ParentActiveRecordModel.make.should be_new_record
+      expect(ParentActiveRecordModel.make).to be_new_record
     end
 
     it "bang should be the same as Fabricate" do
-      ParentActiveRecordModel.make!.should_not be_new_record
+      expect(ParentActiveRecordModel.make!).not_to be_new_record
     end
 
   end
 
   describe "#make sequel", depends_on: :sequel do
     it "should return a fabricated object" do
-      ParentSequelModel.make.should be_instance_of ParentSequelModel
+      expect(ParentSequelModel.make).to be_instance_of ParentSequelModel
     end
 
     it "should be the same as Fabricate.build" do
-      ParentSequelModel.make.should eql(Fabricate.build(:parent_sequel_model))
+      expect(ParentSequelModel.make).to eql(Fabricate.build(:parent_sequel_model))
     end
 
     it "bang should be the same as Fabricate" do
-      ParentSequelModel.make!.id.should_not be_nil
+      expect(ParentSequelModel.make!.id).not_to be_nil
     end
   end
 

--- a/spec/fabrication/transform_spec.rb
+++ b/spec/fabrication/transform_spec.rb
@@ -11,7 +11,7 @@ describe Fabrication::Transform do
     context 'find definitions' do
       context 'transforms are empty' do
         it 'loads the definitions' do
-          Fabrication.manager.should_receive(:load_definitions)
+          expect(Fabrication.manager).to receive(:load_definitions)
           Fabrication::Transform.apply_to(nil, :name => 'Shay')
         end
       end
@@ -19,7 +19,7 @@ describe Fabrication::Transform do
       context 'transforms are not empty' do
         it 'does not load the definitions' do
           Fabrication::Transform.apply_to(nil, :name => 'Shay')
-          Fabrication.manager.should_not_receive(:load_definitions)
+          expect(Fabrication.manager).not_to receive(:load_definitions)
           Fabrication::Transform.apply_to(nil, :name => 'Gabriel')
         end
       end
@@ -36,20 +36,20 @@ describe Fabrication::Transform do
         end
 
         it 'applies the transform to the specified types' do
-          Fabrication::Transform.apply_to(:address, {:city => 'Jacksonville Beach'}).should == {:city => 'JACKSONVILLE BEACH'}
+          expect(Fabrication::Transform.apply_to(:address, {:city => 'Jacksonville Beach'})).to eq({:city => 'JACKSONVILLE BEACH'})
         end
       end
 
       context 'no override has been defined' do
         it 'applies the generic transform' do
-          Fabrication::Transform.apply_to(:address, {:city => 'Jacksonville Beach'}).should == {:city => 'Jacksonville'}
+          expect(Fabrication::Transform.apply_to(:address, {:city => 'Jacksonville Beach'})).to eq({:city => 'Jacksonville'})
         end
       end
     end
 
     context 'when no generic transform has been defined' do
       it 'does not change value' do
-        Fabrication::Transform.apply_to(:address, {:city => 'Jacksonville Beach'}).should == {:city => 'Jacksonville Beach'}
+        expect(Fabrication::Transform.apply_to(:address, {:city => 'Jacksonville Beach'})).to eq({:city => 'Jacksonville Beach'})
       end
     end
 
@@ -61,7 +61,7 @@ describe Fabrication::Transform do
         end
 
         it 'applies corretly' do
-          Fabrication::Transform.apply_to(:address, {:city => 'Jacksonville Beach'}).should == {:city => 'JACKSONVILLE BEACH'}
+          expect(Fabrication::Transform.apply_to(:address, {:city => 'Jacksonville Beach'})).to eq({:city => 'JACKSONVILLE BEACH'})
         end
       end
     end
@@ -72,24 +72,24 @@ describe Fabrication::Transform do
       Fabrication::Transform.define(:name, lambda {|value| value})
       Fabrication::Transform.only_for(:address, :name, lambda {|value| value})
       Fabrication::Transform.clear_all
-      Fabrication::Transform.send(:transforms).should be_empty
-      Fabrication::Transform.send(:overrides).should be_empty
+      expect(Fabrication::Transform.send(:transforms)).to be_empty
+      expect(Fabrication::Transform.send(:overrides)).to be_empty
     end
   end
 
   describe '.define' do
     it 'registers transform' do
-      lambda {
+      expect {
         Fabrication::Transform.define(:name, lambda {|value| value})
-      }.should change(Fabrication::Transform, :transforms)
+      }.to change(Fabrication::Transform, :transforms)
     end
   end
 
   describe '.only_for' do
     it 'registers an override transform for provided model' do
-      lambda {
+      expect {
         Fabrication::Transform.only_for(:address, :name, lambda {|value| value})
-      }.should change(Fabrication::Transform, :overrides)
+      }.to change(Fabrication::Transform, :overrides)
     end
   end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -46,7 +46,7 @@ shared_examples 'something fabricatable' do
 
   context 'state of the object' do
     it 'generates a fresh object every time' do
-      Fabricate(fabricator_name).should_not == subject
+      expect(Fabricate(fabricator_name)).not_to eq(subject)
     end
     it { should be_persisted }
   end
@@ -62,7 +62,7 @@ shared_examples 'something fabricatable' do
 
     it 'cascades to child records' do
       subject.send(collection_field).each do |o|
-        o.should_not be_persisted
+        expect(o).not_to be_persisted
       end
     end
   end
@@ -84,11 +84,11 @@ shared_examples 'something fabricatable' do
     subject { Fabricate("#{Fabrication::Support.singularize(collection_field.to_s)}_with_parent") }
 
     it 'sets the parent association' do
-      subject.send(fabricator_name).should be
+      expect(subject.send(fabricator_name)).to be
     end
 
     it 'sets the id of the associated object' do
-      subject.send("#{fabricator_name}_id").should == subject.send(fabricator_name).id
+      expect(subject.send("#{fabricator_name}_id")).to eq(subject.send(fabricator_name).id)
     end
   end
 end
@@ -170,8 +170,8 @@ describe Fabrication do
       end
 
       it 'generates the right number of objects' do
-        ParentSequelModel.count.should == 3
-        InheritedSequelModel.count.should == 2
+        expect(ParentSequelModel.count).to eq(3)
+        expect(InheritedSequelModel.count).to eq(2)
       end
     end
   end
@@ -201,7 +201,7 @@ describe Fabrication do
     end
 
     it 'evaluates the fields in order of declaration' do
-      parent_ruby_object.string_field.should == "Paul"
+      expect(parent_ruby_object.string_field).to eq("Paul")
     end
   end
 
@@ -215,11 +215,11 @@ describe Fabrication do
     let!(:parent_ruby_object2) { Fabricate(:parent_ruby_object, string_field: 'John') }
 
     it 'parent_ruby_object1 has the correct string field' do
-      parent_ruby_object1.string_field.should == 'Jane'
+      expect(parent_ruby_object1.string_field).to eq('Jane')
     end
 
     it 'parent_ruby_object2 has the correct string field' do
-      parent_ruby_object2.string_field.should == 'John'
+      expect(parent_ruby_object2.string_field).to eq('John')
     end
 
     it 'they have different extra fields' do
@@ -306,19 +306,19 @@ describe Fabrication do
 
   context 'when defining a fabricator twice' do
     it 'throws an error' do
-      lambda { Fabricator(:parent_ruby_object) {} }.should raise_error(Fabrication::DuplicateFabricatorError)
+      expect { Fabricator(:parent_ruby_object) {} }.to raise_error(Fabrication::DuplicateFabricatorError)
     end
   end
 
   context "when defining a fabricator for a class that doesn't exist" do
     it 'throws an error' do
-      lambda { Fabricator(:class_that_does_not_exist) }.should raise_error(Fabrication::UnfabricatableError)
+      expect { Fabricator(:class_that_does_not_exist) }.to raise_error(Fabrication::UnfabricatableError)
     end
   end
 
   context 'when generating from a non-existant fabricator' do
     it 'throws an error' do
-      lambda { Fabricate(:misspelled_fabricator_name) }.should raise_error(Fabrication::UnknownFabricatorError)
+      expect { Fabricate(:misspelled_fabricator_name) }.to raise_error(Fabrication::UnknownFabricatorError)
     end
   end
 
@@ -330,13 +330,13 @@ describe Fabrication do
       end
 
       it 'works fine' do
-        Fabricate(:widget).should be
+        expect(Fabricate(:widget)).to be
       end
     end
 
     context 'for a non-existant class' do
       it "raises an error if the class cannot be located" do
-        lambda { Fabricator(:somenonexistantclass) }.should raise_error(Fabrication::UnfabricatableError)
+        expect { Fabricator(:somenonexistantclass) }.to raise_error(Fabrication::UnfabricatableError)
       end
     end
   end
@@ -360,7 +360,7 @@ describe Fabrication do
     after { Fabrication.manager.freeze }
 
     it 'throws an error' do
-      lambda { Fabricate(:your_mom) }.should raise_error(Fabrication::MisplacedFabricateError)
+      expect { Fabricate(:your_mom) }.to raise_error(Fabrication::MisplacedFabricateError)
     end
   end
 


### PR DESCRIPTION
Update RSpec suite to new expect syntax using the Transpec gem.

A few syntax types were excluded:

One liners - To enhance readability, one line it... should syntax blocks were ignored
Have Items - Instead of comparing against size, a test that expected have(number).items was kept
Its - Expectations of attrubutes on subject were not converted. This relates mostly to the one-liners.

A summary log of the changes can be found below. The complete changes are available in the diff.

All tests pass before and after the conversion.

This conversion is done by Transpec 2.3.4 with the following command:
    transpec --keep its --keep oneliner --keep have_items
- 122 conversions
  from: obj.should
    to: expect(obj).to
- 93 conversions
  from: == expected
    to: eq(expected)
- 10 conversions
  from: lambda { }.should
    to: expect { }.to
- 10 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 6 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 6 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
- 5 conversions
  from: === expected
    to: be === expected
- 1 conversion
  from: obj.should_not_receive(:message)
    to: expect(obj).not_to receive(:message)

For more details: https://github.com/yujinakayama/transpec#supported-conversions
