### PR TITLE
allows #count to take a range argument for random count

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -12,7 +12,7 @@ appraise 'blank-slate' do
 end
 
 appraise 'rails-4.2' do
-  gem 'activerecord', '~> 4.2.0.beta4', require: 'active_record'
+  gem 'activerecord', '~> 4.2.0.rc1', require: 'active_record'
 end
 
 appraise 'rails-4.1' do

--- a/lib/fabrication/schematic/attribute.rb
+++ b/lib/fabrication/schematic/attribute.rb
@@ -41,19 +41,19 @@ class Fabrication::Schematic::Attribute
   end
 
   def process_count
-    count || rand || rand_range
+    count || rand
   end
 
   def count
-    params[:count]
+    if params[:count].is_a?(Range)
+      Kernel.rand((params[:count].begin..params[:count].end))
+    else
+      params[:count]
+    end
   end
 
   def rand
     Kernel.rand((1..params[:rand])) if params[:rand]
-  end
-
-  def rand_range
-    Kernel.rand((params[:start_range]..params[:end_range])) if params[:start_range] && params[:end_range]
   end
 
 end

--- a/lib/fabrication/schematic/attribute.rb
+++ b/lib/fabrication/schematic/attribute.rb
@@ -45,15 +45,15 @@ class Fabrication::Schematic::Attribute
   end
 
   def count
-    if params[:count].is_a?(Range)
-      Kernel.rand((params[:count].begin..params[:count].end))
-    else
-      params[:count]
-    end
+    params[:count]
   end
 
   def rand
-    Kernel.rand((1..params[:rand])) if params[:rand]
+    if params[:rand].is_a?(Range)
+      Kernel.rand((params[:rand].begin..params[:rand].end))
+    else
+      Kernel.rand((1..params[:rand])) if params[:rand]
+    end
   end
 
 end

--- a/spec/fabrication/schematic/attribute_spec.rb
+++ b/spec/fabrication/schematic/attribute_spec.rb
@@ -74,10 +74,10 @@ describe Fabrication::Schematic::Attribute do
       let(:range_start) { 10 }
       let(:range_end) { 21 }
       let(:attribute) do
-        Fabrication::Schematic::Attribute.new(Object, "a", nil, {count: (range_start)..(range_end)}) { 'something' }
+        Fabrication::Schematic::Attribute.new(Object, "a", nil, {rand: (range_start)..(range_end)}) { 'something' }
       end
 
-      it 'returns random number of items in collection with a min and max of passed in value' do
+      it 'returns random number of items in collection with a min and max of passed in values' do
         expect(range_start..range_end).to be_member(attribute.processed_value({}).length)
       end
     end

--- a/spec/fabrication/schematic/attribute_spec.rb
+++ b/spec/fabrication/schematic/attribute_spec.rb
@@ -74,7 +74,7 @@ describe Fabrication::Schematic::Attribute do
       let(:range_start) { 10 }
       let(:range_end) { 21 }
       let(:attribute) do
-        Fabrication::Schematic::Attribute.new(Object, "a", nil, {start_range: range_start, end_range: range_end}) { 'something' }
+        Fabrication::Schematic::Attribute.new(Object, "a", nil, {count: (range_start)..(range_end)}) { 'something' }
       end
 
       it 'returns random number of items in collection with a min and max of passed in value' do


### PR DESCRIPTION
This seems to work, however it also begs the question if ```rand``` ought to be depreciated since ```count``` can now handle rands. So instead of rand: whatever, you can use count for fixed counts or random counts. Seems like that might clean up the API even more.

If you have a better way to write this code, please let me know.