### PR TITLE
Lazily create schematic definitions

### DIFF
--- a/spec/fabrication/schematic/manager_spec.rb
+++ b/spec/fabrication/schematic/manager_spec.rb
@@ -18,21 +18,21 @@ describe Fabrication::Schematic::Manager do
     end
 
     it "creates a schematic" do
-      expect(subject.schematics[:open_struct]).to be
+      expect(subject[:open_struct]).to be
     end
 
     it "has the correct class" do
-      expect(subject.schematics[:open_struct].klass).to eq(OpenStruct)
+      expect(subject[:open_struct].klass).to eq(OpenStruct)
     end
 
     it "has the attributes" do
-      expect(subject.schematics[:open_struct].attributes.size).to eq(2)
+      expect(subject[:open_struct].attributes.size).to eq(2)
     end
 
     context "with an alias" do
       it "recognizes the aliases" do
-        expect(subject.schematics[:thing_one]).to eq(subject.schematics[:open_struct])
-        expect(subject.schematics[:thing_two]).to eq(subject.schematics[:open_struct])
+        expect(subject[:thing_one]).to eq(subject[:open_struct])
+        expect(subject[:thing_two]).to eq(subject[:open_struct])
       end
     end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -310,12 +310,6 @@ describe Fabrication do
     end
   end
 
-  context "when defining a fabricator for a class that doesn't exist" do
-    it 'throws an error' do
-      expect { Fabricator(:class_that_does_not_exist) }.to raise_error(Fabrication::UnfabricatableError)
-    end
-  end
-
   context 'when generating from a non-existant fabricator' do
     it 'throws an error' do
       expect { Fabricate(:misspelled_fabricator_name) }.to raise_error(Fabrication::UnknownFabricatorError)
@@ -331,12 +325,6 @@ describe Fabrication do
 
       it 'works fine' do
         expect(Fabricate(:widget)).to be
-      end
-    end
-
-    context 'for a non-existant class' do
-      it "raises an error if the class cannot be located" do
-        expect { Fabricator(:somenonexistantclass) }.to raise_error(Fabrication::UnfabricatableError)
       end
     end
   end


### PR DESCRIPTION
Option for #244

Probably not the cleanest way to do it, but it was a quick stab. This waits until something is fabricated to resolve the class which means fabrication no longer loads every class you have a fabricator for on test start.