### PR TITLE
Support rake >10.0 by including Rake::DSL

### DIFF
--- a/lib/fabrication.rb
+++ b/lib/fabrication.rb
@@ -2,6 +2,7 @@ autoload :Fabricate, 'fabricate'
 
 if defined?(Rake)
   require 'rake'
+  include Rake::DSL
   Dir[File.join(File.dirname(__FILE__), 'tasks', '**/*.rake')].each { |rake| load rake }
 end
 


### PR DESCRIPTION
When using rake versions 10.0 and above in a project, using `desc` and `task`
in the global namespace are no longer supported. As fabrication gem loads
lib/tasks/defined_fabricators.rake in the presence of rake, it generates
a warning in rake 0.9.* and errors in rake 10.*. This commit includes
Rake::DSL before loading lib/tasks/*.rake, which allows for error free
use of existing `desc` and `task`.