### PR TITLE
Avoid warnings

### DIFF
--- a/lib/fabrication/config.rb
+++ b/lib/fabrication/config.rb
@@ -43,6 +43,8 @@ module Fabrication
     alias path_prefixes path_prefix
 
     attr_writer :register_with_steps
-    def register_with_steps?; @register_with_steps end
+    def register_with_steps?
+      @register_with_steps ||= nil
+    end
   end
 end

--- a/lib/fabrication/config.rb
+++ b/lib/fabrication/config.rb
@@ -27,7 +27,7 @@ module Fabrication
 
     def fabricator_dir=(folders)
       puts "DEPRECATION WARNING: Fabrication::Config.fabricator_dir has been replaced by Fabrication::Config.fabricator_path"
-      fabricator_path = folders
+      self.fabricator_path = folders
     end
 
     attr_writer :sequence_start

--- a/lib/fabrication/generator/base.rb
+++ b/lib/fabrication/generator/base.rb
@@ -51,7 +51,7 @@ class Fabrication::Generator::Base
   end
 
   def build_instance_with_constructor_override(callback)
-    self._instance = instance_eval &callback
+    self._instance = instance_eval(&callback)
     set_attributes
   end
 

--- a/lib/fabrication/schematic/attribute.rb
+++ b/lib/fabrication/schematic/attribute.rb
@@ -1,6 +1,7 @@
 class Fabrication::Schematic::Attribute
 
-  attr_accessor :klass, :name, :params, :value
+  attr_accessor :klass, :name, :value
+  attr_writer :params
 
   def initialize(klass, name, value, params={}, &block)
     self.klass = klass

--- a/lib/fabrication/schematic/definition.rb
+++ b/lib/fabrication/schematic/definition.rb
@@ -119,7 +119,10 @@ class Fabrication::Schematic::Definition
 
   protected
 
-  def loaded?; !!@loaded end
+  def loaded?
+    !!(@loaded ||= nil)
+  end
+
   def load_body
     return if loaded?
     @loaded = true

--- a/lib/fabrication/schematic/manager.rb
+++ b/lib/fabrication/schematic/manager.rb
@@ -8,7 +8,9 @@ class Fabrication::Schematic::Manager
     clear
   end
 
-  def initializing?; @initializing end
+  def initializing?
+    @initializing ||= nil
+  end
 
   def schematics
     @schematics ||= {}

--- a/spec/support/plain_old_ruby_objects.rb
+++ b/spec/support/plain_old_ruby_objects.rb
@@ -2,7 +2,7 @@ require 'ostruct'
 
 class Persistable
   def persisted?
-    @persisted
+    @persisted ||= nil
   end
   def save!
     @persisted = true

--- a/spec/support/plain_old_ruby_objects.rb
+++ b/spec/support/plain_old_ruby_objects.rb
@@ -42,9 +42,11 @@ end
 
 class ChildRubyObject < Persistable
   attr_accessor \
-    :parent_ruby_object,
     :parent_ruby_object_id,
     :number_field
+
+  attr_reader \
+    :parent_ruby_object
 
   def parent_ruby_object=(parent_ruby_object)
     @parent_ruby_object = parent_ruby_object


### PR DESCRIPTION
Ruby Warnings found:

 108 lib/fabrication/config.rb:46: warning: instance variable @register_with_steps not initialized
  98 lib/fabrication/schematic/definition.rb:122: warning: instance variable @loaded not initialized
   4 spec/support/plain_old_ruby_objects.rb:5: warning: instance variable @persisted not initialized
   1 spec/support/sequel.rb:22: warning: assigned but unused variable - strict_param_setting
   1 spec/support/plain_old_ruby_objects.rb:49: warning: method redefined; discarding old parent_ruby_object=
   1 lib/fabrication/schematic/manager.rb:11: warning: instance variable @initializing not initialized
   1 lib/fabrication/schematic/attribute.rb:12: warning: method redefined; discarding old params
   1 lib/fabrication/generator/base.rb:54: warning: `&' interpreted as argument prefix
   1 lib/fabrication/config.rb:30: warning: assigned but unused variable - fabricator_path

There are other 3 warnings on tests you can avoid updating rspec.