### PR TITLE
Set Fabrication as a fixture replacement in Rails

### DIFF
--- a/lib/fabrication.rb
+++ b/lib/fabrication.rb
@@ -1,3 +1,5 @@
+require 'fabrication/railtie' if defined?(Rails)
+
 autoload :Fabricate, 'fabricate'
 
 if defined?(Rake)

--- a/lib/fabrication/railtie.rb
+++ b/lib/fabrication/railtie.rb
@@ -1,0 +1,17 @@
+module Fabrication
+  class Railtie < Rails::Railtie
+    initializer 'fabrication.set_fixture_replacement' do
+      # Rails 3.0.1 and up uses `app_generators`
+      generators =
+        if config.respond_to?(:app_generators)
+          config.app_generators
+        else
+          config.generators
+        end
+
+      unless generators.rails.has_key?(:fixture_replacement)
+        generators.fixture_replacement :fabrication
+      end
+    end
+  end
+end


### PR DESCRIPTION
Eliminates the need to manually configure the `fixture_replacement` generator option for RSpec.