### PR TITLE
Add support for custom generators

### DIFF
--- a/lib/fabrication/config.rb
+++ b/lib/fabrication/config.rb
@@ -8,6 +8,7 @@ module Fabrication
       @fabricator_path =
         @path_prefix =
         @sequence_start =
+        @generators =
         nil
     end
 
@@ -45,6 +46,12 @@ module Fabrication
     attr_writer :register_with_steps
     def register_with_steps?
       @register_with_steps ||= nil
+    end
+
+    def generators; @generators ||= [] end
+
+    def generator_for(default_generators, klass)
+      (generators + default_generators).detect { |gen| gen.supports?(klass) }
     end
   end
 end

--- a/lib/fabrication/schematic/definition.rb
+++ b/lib/fabrication/schematic/definition.rb
@@ -46,7 +46,7 @@ class Fabrication::Schematic::Definition
   end
 
   def generator
-    @generator ||= GENERATORS.detect { |gen| gen.supports?(klass) }
+    @generator ||= Fabrication::Config.generator_for(GENERATORS, klass)
   end
 
   def sorted_attributes

--- a/spec/fabrication/config_spec.rb
+++ b/spec/fabrication/config_spec.rb
@@ -53,4 +53,14 @@ describe Fabrication::Config do
       its(:path_prefix) { should == ['/path/to/app', '/path/to/gem/fabricators'] }
     end
   end
+
+  describe ".register_generator" do
+    before do
+      Fabrication.configure do |config|
+        config.generators << ImmutableGenerator
+      end
+    end
+
+    its(:generators) { should == [ImmutableGenerator] }
+  end
 end

--- a/spec/fabrication/generator/base_spec.rb
+++ b/spec/fabrication/generator/base_spec.rb
@@ -136,6 +136,23 @@ describe Fabrication::Generator::Base do
       end
       its(:string_field) { should == '1' }
     end
+
+    context 'with custom generators' do
+      before do
+        Fabrication.configure do |config|
+          config.generators << ImmutableGenerator
+        end
+      end
+
+      after do
+        Fabrication::Config.reset_defaults
+      end
+
+      it "uses custom generator" do
+        user = Fabricate(:immutable_user, name: 'foo')
+        expect(user.name).to eq('foo')
+      end
+    end
   end
 
   describe '#create' do

--- a/spec/fabricators/plain_old_ruby_object_fabricator.rb
+++ b/spec/fabricators/plain_old_ruby_object_fabricator.rb
@@ -30,3 +30,7 @@ Fabricator(:predefined_namespaced_class, from: 'namespaced_classes/ruby_object')
 end
 
 Fabricator(:troublemaker)
+
+Fabricator(:immutable_user) do
+  name 'abc'
+end

--- a/spec/support/plain_old_ruby_objects.rb
+++ b/spec/support/plain_old_ruby_objects.rb
@@ -76,3 +76,23 @@ end
 
 class ClassWithInit < Struct.new(:arg1, :arg2)
 end
+
+class ImmutableUser
+  def initialize(attributes)
+    @attributes = attributes.to_hash
+  end
+
+  def name
+    @attributes.fetch(:name)
+  end
+end
+
+class ImmutableGenerator < Fabrication::Generator::Base
+  def self.supports?(klass)
+    klass == ImmutableUser
+  end
+
+  def build_instance
+    self._instance = _klass.new(_attributes)
+  end
+end


### PR DESCRIPTION
This opens the possibility for third-party gems to build bridges between
Fabrication and non-officially supported ORMs.

```ruby
class CustomGenerator < Fabrication::Generator::Base
  def self.supports?(klass)
    # detect if it can support klass
  end

  # customize the behavior
end

Fabrication.configure do |config|
  config.generators << CustomGenerator
end
```

---

I want to build an `hanami-fabrication` gem to support the upcoming version of `hanami-model` which uses `rom` as engine. That's why it would be great if you can accept this proposal.

---

Thank you for Fabrication 💚 