### PR TITLE
Do not include Rake::DSL in the top-level scope

### DIFF
--- a/lib/fabrication.rb
+++ b/lib/fabrication.rb
@@ -4,7 +4,6 @@ autoload :Fabricate, 'fabricate'
 
 if defined?(Rake)
   require 'rake'
-  include Rake::DSL
   Dir[File.join(File.dirname(__FILE__), 'tasks', '**/*.rake')].each { |rake| load rake }
 end
 


### PR DESCRIPTION
fixes #289.

The commit fd0424b changed the `lib/fabrication.rb` file to include the `Rake::DSL` module, but it turns out that this call is unnecessary since Fabrication's rake definition is in fact compatible with both of Rake 0.9.* and 10.*. Also, it had brought the deprecated feature back in without showing any deprecation warnings, and I don't believe it is expected.

This commit removes the include call since it is 100% safe to do so.