### PR TITLE
require railtie only if Rails::Railtie is defined

### DIFF
--- a/lib/fabrication.rb
+++ b/lib/fabrication.rb
@@ -1,4 +1,4 @@
-require 'fabrication/railtie' if defined?(Rails)
+require 'fabrication/railtie' if defined?(Rails::Railtie)
 
 autoload :Fabricate, 'fabricate'
 


### PR DESCRIPTION
The constant Rails can occur in many other gems besides RoR itself, like rails-html-sanitizer and rails-dom-testing dependencies of actionview, which does not depend on RoR or Rails::Railtie. If it more reliable to test for the actual Rails::Railtie.

Excerpt from a real life case:
```ruby
gem 'sinatra'
gem 'actionview' # for cloudinary
gem 'cloudinary'
# no gem rails or other rails-related gems
``` 
Issue fixed by the PR:
```
/gems/fabrication-2.16.1/lib/fabrication/railtie.rb:2:in `<module:Fabrication>': uninitialized constant Rails::Railtie (NameError)
        from /gems/fabrication-2.16.1/lib/fabrication/railtie.rb:1:in `<top (required)>'
        from /gems/backports-3.8.0/lib/backports/std_lib.rb:9:in `require'
        from /gems/backports-3.8.0/lib/backports/std_lib.rb:9:in `require_with_backports'
        from /gems/fabrication-2.16.1/lib/fabrication.rb:1:in `<top (required)>'
        from /gems/backports-3.8.0/lib/backports/std_lib.rb:9:in `require'
        from /gems/backports-3.8.0/lib/backports/std_lib.rb:9:in `require_with_backports'
```