### PR TITLE
Raise error on infinite recursion

### DIFF
--- a/lib/fabrication.rb
+++ b/lib/fabrication.rb
@@ -12,6 +12,7 @@ module Fabrication
   autoload :UnfabricatableError,      'fabrication/errors/unfabricatable_error'
   autoload :UnknownFabricatorError,   'fabrication/errors/unknown_fabricator_error'
   autoload :MisplacedFabricateError,  'fabrication/errors/misplaced_fabricate_error'
+  autoload :InfiniteRecursionError,   'fabrication/errors/infinite_recursion_error'
 
   module Schematic
     autoload :Attribute,  'fabrication/schematic/attribute'

--- a/lib/fabrication/config.rb
+++ b/lib/fabrication/config.rb
@@ -53,5 +53,8 @@ module Fabrication
     def generator_for(default_generators, klass)
       (generators + default_generators).detect { |gen| gen.supports?(klass) }
     end
+
+    def recursion_limit; @recursion_limit ||= 20 end
+    def recursion_limit=(limit); @recursion_limit = limit end
   end
 end

--- a/lib/fabrication/errors/infinite_recursion_error.rb
+++ b/lib/fabrication/errors/infinite_recursion_error.rb
@@ -1,0 +1,5 @@
+class Fabrication::InfiniteRecursionError < StandardError
+  def initialize(name)
+    super("You appear to have infinite recursion with the `#{name}` fabricator")
+  end
+end

--- a/lib/fabrication/schematic/definition.rb
+++ b/lib/fabrication/schematic/definition.rb
@@ -59,7 +59,7 @@ class Fabrication::Schematic::Definition
       to_params(overrides, &block)
     else
       begin
-        Fabrication.manager.build_stack << self
+        Fabrication.manager.build_stack << name
         merge(overrides, &block).instance_eval do
           generator.new(klass).build(sorted_attributes, callbacks)
         end
@@ -77,7 +77,7 @@ class Fabrication::Schematic::Definition
       to_params(overrides, &block)
     else
       begin
-        Fabrication.manager.create_stack << self
+        Fabrication.manager.create_stack << name
         merge(overrides, &block).instance_eval do
           generator.new(klass).create(sorted_attributes, callbacks)
         end
@@ -89,7 +89,7 @@ class Fabrication::Schematic::Definition
 
   def to_params(overrides={}, &block)
     Fabrication.manager.prevent_recursion!
-    Fabrication.manager.to_params_stack << self
+    Fabrication.manager.to_params_stack << name
     merge(overrides, &block).instance_eval do
       generator.new(klass).to_params(sorted_attributes)
     end

--- a/lib/fabrication/schematic/manager.rb
+++ b/lib/fabrication/schematic/manager.rb
@@ -33,6 +33,10 @@ class Fabrication::Schematic::Manager
     schematics[name.to_sym]
   end
 
+  def create_stack
+    @create_stack ||= []
+  end
+
   def build_stack
     @build_stack ||= []
   end
@@ -54,6 +58,12 @@ class Fabrication::Schematic::Manager
     raise e
   ensure
     freeze
+  end
+
+  def prevent_recursion!
+    (create_stack + build_stack + to_params_stack).map(&:name).group_by(&:to_sym).each do |name, values|
+      raise Fabrication::InfiniteRecursionError.new(name) if values.length > Fabrication::Config.recursion_limit
+    end
   end
 
   protected

--- a/lib/fabrication/schematic/manager.rb
+++ b/lib/fabrication/schematic/manager.rb
@@ -61,7 +61,7 @@ class Fabrication::Schematic::Manager
   end
 
   def prevent_recursion!
-    (create_stack + build_stack + to_params_stack).map(&:name).group_by(&:to_sym).each do |name, values|
+    (create_stack + build_stack + to_params_stack).group_by(&:to_sym).each do |name, values|
       raise Fabrication::InfiniteRecursionError.new(name) if values.length > Fabrication::Config.recursion_limit
     end
   end


### PR DESCRIPTION
This PR changes fabrication to raise a more meaningful error when it detects a recursive scenario in your fabricator definitions.

It assumes that 20 nested attempts to create an object is likely infinite recursion. This can be adjusted in the config if necessary.

```
Fabrication::Config.recursion_limit = 20
```

Fixes #303 