### PR TITLE
Fabrication::Generator::Sequel should raise on error

### DIFF
--- a/lib/fabrication/generator/sequel.rb
+++ b/lib/fabrication/generator/sequel.rb
@@ -23,7 +23,7 @@ class Fabrication::Generator::Sequel < Fabrication::Generator::Base
   end
 
   def persist
-    _instance.save
+    _instance.save(raise_on_failure: true)
   end
 
   private


### PR DESCRIPTION
AR generator uses `save!`, sequel analog is `save(raise_on_failure: true)`