### PR TITLE
Make Definition#klass public again

### DIFF
--- a/lib/fabrication/schematic/definition.rb
+++ b/lib/fabrication/schematic/definition.rb
@@ -130,6 +130,15 @@ class Fabrication::Schematic::Definition
     end
   end
 
+  def klass
+    @klass ||= Fabrication::Support.class_for(
+      options[:class_name] ||
+        (parent && parent.klass) ||
+        options[:from] ||
+        name
+    )
+  end
+
   protected
 
   def loaded?
@@ -151,14 +160,5 @@ class Fabrication::Schematic::Definition
 
   def parent
     @parent ||= Fabrication.manager[options[:from].to_s] if options[:from]
-  end
-
-  def klass
-    @klass ||= Fabrication::Support.class_for(
-      options[:class_name] ||
-        (parent && parent.klass) ||
-        options[:from] ||
-        name
-    )
   end
 end

--- a/spec/fabrication/schematic/definition_spec.rb
+++ b/spec/fabrication/schematic/definition_spec.rb
@@ -253,4 +253,9 @@ describe Fabrication::Schematic::Definition do
     end
     it { should == [:one, :two, :three] }
   end
+
+  describe '#klass' do
+    subject { schematic.klass }
+    it { should be OpenStruct }
+  end
 end


### PR DESCRIPTION
`rake fabrication:list` uses definition klass to group schemas.
And in general there's no point in protecting this method.