### PR TITLE
Verify that ActiveRecord::Base is defined when checking for support

### DIFF
--- a/lib/fabrication/generator/active_record.rb
+++ b/lib/fabrication/generator/active_record.rb
@@ -1,7 +1,11 @@
 class Fabrication::Generator::ActiveRecord < Fabrication::Generator::Base
 
   def self.supports?(klass)
-    defined?(ActiveRecord) && klass.ancestors.include?(ActiveRecord::Base)
+    # Some gems will declare an ActiveRecord module for their own purposes
+    # so we can't assume because we have the ActiveRecord module that we also
+    # have ActiveRecord::Base. Because defined? can return nil we ensure that nil
+    # becomes false.
+    defined?(ActiveRecord) && defined?(ActiveRecord::Base) && klass.ancestors.include?(ActiveRecord::Base) || false
   end
 
   def build_instance

--- a/spec/fabrication/generator/active_record_spec.rb
+++ b/spec/fabrication/generator/active_record_spec.rb
@@ -1,5 +1,22 @@
 require 'spec_helper'
 
+describe Fabrication::Generator::ActiveRecord do
+  describe ".supports?" do
+    subject { Fabrication::Generator::ActiveRecord }
+
+    # Defines a fakey ActiveRecord module that doesn't also have
+    # ActiveRecord::Base such as those written by instrumentation
+    # platforms e.g. Honeycomb
+    module ActiveRecord; end
+
+    let(:active_record_fake) { ActiveRecord }
+
+    it "returns false for active record objects without ar::base" do
+      expect(subject.supports?(active_record_fake)).to be false
+    end
+  end
+end
+
 describe Fabrication::Generator::ActiveRecord, depends_on: :active_record do
 
   describe ".supports?" do


### PR DESCRIPTION
Some gems will create an `ActiveRecord` module, but if you
aren't using already using AR you won't have AR::Base loaded.

The previous check would throw an exception in that scenrio.

I've modified the check to detect that `ActiveRecord::Base` is also defined.