### PR TITLE
Remove global Fabrication.manager reference in Defintion

### DIFF
--- a/lib/fabrication/schematic/manager.rb
+++ b/lib/fabrication/schematic/manager.rb
@@ -73,7 +73,7 @@ class Fabrication::Schematic::Manager
   end
 
   def store(name, aliases, options, &block)
-    schematic = schematics[name] = Fabrication::Schematic::Definition.new(name, options, &block)
+    schematic = schematics[name] = Fabrication::Schematic::Definition.new(name, self, options, &block)
     aliases.each { |as| schematics[as.to_sym] = schematic }
   end
 

--- a/spec/fabrication/generator/base_spec.rb
+++ b/spec/fabrication/generator/base_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe Fabrication::Generator::Base do
+  let(:manager) { Fabrication.manager }
 
   describe ".supports?" do
     subject { Fabrication::Generator::Base }
@@ -14,7 +15,7 @@ describe Fabrication::Generator::Base do
     let(:generator) { Fabrication::Generator::Base.new(ParentRubyObject) }
 
     let(:attributes) do
-      Fabrication::Schematic::Definition.new('ParentRubyObject') do
+      Fabrication::Schematic::Definition.new('ParentRubyObject', manager) do
         string_field 'different content'
         extra_fields(count: 4) { |attrs, index| "field #{index}" }
       end.attributes
@@ -39,7 +40,7 @@ describe Fabrication::Generator::Base do
 
       context "using init_with" do
         let(:schematic) do
-          Fabrication::Schematic::Definition.new('ClassWithInit') do
+          Fabrication::Schematic::Definition.new('ClassWithInit', manager) do
             on_init { init_with(:a, :b) }
           end
         end
@@ -52,7 +53,7 @@ describe Fabrication::Generator::Base do
 
       context "not using init_with" do
         let(:schematic) do
-          Fabrication::Schematic::Definition.new('ClassWithInit') do
+          Fabrication::Schematic::Definition.new('ClassWithInit', manager) do
             on_init { [ :a, :b ] }
           end
         end
@@ -70,7 +71,7 @@ describe Fabrication::Generator::Base do
 
       context "using only raw values" do
         let(:schematic) do
-          Fabrication::Schematic::Definition.new('ClassWithInit') do
+          Fabrication::Schematic::Definition.new('ClassWithInit', manager) do
             initialize_with { Struct.new(:arg1, :arg2).new(:fixed_value) }
           end
         end
@@ -83,7 +84,7 @@ describe Fabrication::Generator::Base do
 
       context "using attributes inside block" do
         let(:schematic) do
-           Fabrication::Schematic::Definition.new('ClassWithInit') do
+           Fabrication::Schematic::Definition.new('ClassWithInit', manager) do
              arg1 10
              initialize_with { Struct.new(:arg1, :arg2).new(arg1, arg1 + 10) }
           end
@@ -109,7 +110,7 @@ describe Fabrication::Generator::Base do
 
     context "using an after_create hook" do
       let(:schematic) do
-        Fabrication::Schematic::Definition.new('ParentRubyObject') do
+        Fabrication::Schematic::Definition.new('ParentRubyObject', manager) do
           string_field 'something'
           after_create { |k| k.string_field.upcase! }
         end
@@ -127,7 +128,7 @@ describe Fabrication::Generator::Base do
     context 'all the callbacks' do
       subject { schematic.build }
       let(:schematic) do
-        Fabrication::Schematic::Definition.new('ParentRubyObject') do
+        Fabrication::Schematic::Definition.new('ParentRubyObject', manager) do
           string_field ""
           after_build { |k| k.string_field += '1' }
           before_validation { |k| k.string_field += '2' }
@@ -159,7 +160,7 @@ describe Fabrication::Generator::Base do
     context 'all the callbacks' do
       subject { schematic.fabricate }
       let(:schematic) do
-        Fabrication::Schematic::Definition.new('ParentRubyObject') do
+        Fabrication::Schematic::Definition.new('ParentRubyObject', manager) do
           string_field ""
           after_build { |k| k.string_field += '1' }
           before_validation { |k| k.string_field += '2' }

--- a/spec/fabrication/schematic/definition_spec.rb
+++ b/spec/fabrication/schematic/definition_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Fabrication::Schematic::Definition do
-
+  let(:manager) { Fabrication.manager }
   let(:schematic) do
-    Fabrication::Schematic::Definition.new('OpenStruct') do
+    Fabrication::Schematic::Definition.new('OpenStruct', manager) do
       name "Orgasmo"
       something(:param => 2) { "hi!" }
       another_thing { 25 }
@@ -165,7 +165,7 @@ describe Fabrication::Schematic::Definition do
     let(:init_block) { lambda {} }
     let(:init_schematic) do
       block = init_block
-      Fabrication::Schematic::Definition.new('OpenStruct') do
+      Fabrication::Schematic::Definition.new('OpenStruct', manager) do
         on_init(&block)
       end
     end
@@ -193,7 +193,7 @@ describe Fabrication::Schematic::Definition do
     let(:init_block) { lambda {} }
     let(:init_schematic) do
       block = init_block
-      Fabrication::Schematic::Definition.new('OpenStruct') do
+      Fabrication::Schematic::Definition.new('OpenStruct', manager) do
         initialize_with(&block)
       end
     end
@@ -219,7 +219,7 @@ describe Fabrication::Schematic::Definition do
 
   describe '#transient' do
     let(:definition) do
-      Fabrication::Schematic::Definition.new('OpenStruct') do
+      Fabrication::Schematic::Definition.new('OpenStruct', manager) do
         transient :one, :two => 'with a default value', :three => 200
       end
     end
@@ -245,7 +245,7 @@ describe Fabrication::Schematic::Definition do
   describe '#sorted_attributes' do
     subject { definition.sorted_attributes.map(&:name) }
     let(:definition) do
-      Fabrication::Schematic::Definition.new('OpenStruct') do
+      Fabrication::Schematic::Definition.new('OpenStruct', manager) do
         three { nil }
         one ''
         transient :two

--- a/spec/fabrication/schematic/evaluator_spec.rb
+++ b/spec/fabrication/schematic/evaluator_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Fabrication::Schematic::Evaluator do
-  let(:definition) { Fabrication::Schematic::Definition.new(ParentRubyObject) }
+  let(:manager) { Fabrication.manager }
+  let(:definition) { Fabrication::Schematic::Definition.new(ParentRubyObject, manager) }
   let(:evaluator) { Fabrication::Schematic::Evaluator.new }
 
   describe 'attribute handling' do


### PR DESCRIPTION
Opening this PR to see if you're open to me removing more global references inside of Fabrication.

I have a weird use case where I need to use Fabrication both for testing/development in rails, but I also need a completely separate object generate in production that will live in `app/factories`. I'm hoping to isolate all of the global/singleton state into one class that lives outside of the Manager for the "normal" test/development use case.