### PR TITLE
Handle Namespace

### DIFF
--- a/lib/rails/generators/fabrication/model/model_generator.rb
+++ b/lib/rails/generators/fabrication/model/model_generator.rb
@@ -9,7 +9,12 @@ module Fabrication
 
       def create_fabrication_file
         copy_attributes_from_model if attributes.empty?
-        template 'fabricator.erb', File.join(options[:dir], "#{singular_table_name}_fabricator.#{options[:extension].to_s}")
+        template_file = File.join(
+          options[:dir],
+          class_path,
+          "#{file_name}_fabricator.#{options[:extension].to_s}"
+        )
+        template 'fabricator.erb', template_file
       end
 
       def self.source_root

--- a/lib/rails/generators/fabrication/model/templates/fabricator.erb
+++ b/lib/rails/generators/fabrication/model/templates/fabricator.erb
@@ -1,6 +1,8 @@
-Fabricator(<%= class_name.match(/::/) ? "'#{class_name}'" : ":#{singular_name}" %>) do
+<% module_namespacing do -%>
+Fabricator(<%= class_name.match(/::/) ? "'#{class_name}'" : ":#{singular_name}" %><%= namespaced? ? ", from: #{class_name}" : ""%>) do
 <% width = attributes.map{|a| a.name.size }.max.to_i -%>
 <% attributes.each do |attribute| -%>
   <%= "%-#{width}s %s" % [attribute.name, attribute.default.inspect] %>
 <% end -%>
 end
+<% end -%>

--- a/lib/rails/generators/fabrication/model/templates/fabricator.erb
+++ b/lib/rails/generators/fabrication/model/templates/fabricator.erb
@@ -1,8 +1,10 @@
-<% module_namespacing do -%>
-Fabricator(<%= class_name.match(/::/) ? "'#{class_name}'" : ":#{singular_name}" %><%= namespaced? ? ", from: #{class_name}" : ""%>) do
+<% if namespaced? -%>
+Fabricator(<%= ":#{singular_name}, from: '#{namespace}::#{class_name}'" %>) do
+<% else -%>
+Fabricator(<%= class_name.match(/::/) ? "'#{class_name}'" : ":#{singular_name}" %>) do
+<% end -%>
 <% width = attributes.map{|a| a.name.size }.max.to_i -%>
 <% attributes.each do |attribute| -%>
   <%= "%-#{width}s %s" % [attribute.name, attribute.default.inspect] %>
 <% end -%>
 end
-<% end -%>


### PR DESCRIPTION
If you create a `Rails Engine` it comes with the namespace, and `fabrication` doesn't handle it properly.

`rails _6.0.1_ plugin new foo --mountable`

`rails g scaffold Widget name:string`

```
invoke      fabrication
create      spec/fabricators/foo_widget_fabricator.rb
```

```
Fabricator(:widget) do
  name "MyString"
end
```

Hence you have to constantly fix the fabricators generated 

in this case it would be expected to have 

```
invoke      fabrication
create      spec/fabricators/foo/widget_fabricator.rb
```

like the `railties` generator does with `model`

this PR give the right behavior with `rails g model`

```
module Foo
  Fabricator(:widget, from: Widget) do
    name "MyString"
  end
end
```

