### PR TITLE
Allow overrides to be `nil`

### DIFF
--- a/lib/fabrication/generator/base.rb
+++ b/lib/fabrication/generator/base.rb
@@ -76,7 +76,7 @@ class Fabrication::Generator::Base
   end
 
   def method_missing(method_name, *args, &block)
-    _attributes[method_name] || super
+    _attributes.fetch(method_name) { super }
   end
 
   protected

--- a/spec/fabrication/generator/base_spec.rb
+++ b/spec/fabrication/generator/base_spec.rb
@@ -85,7 +85,7 @@ describe Fabrication::Generator::Base do
         let(:schematic) do
            Fabrication::Schematic::Definition.new('ClassWithInit') do
              arg1 10
-             initialize_with { Struct.new(:arg1, :arg2).new(arg1, arg1 + 10) }
+             initialize_with { Struct.new(:arg1, :arg2).new(arg1, arg1.to_i + 10) }
           end
         end
 
@@ -104,6 +104,13 @@ describe Fabrication::Generator::Base do
           end
         end
 
+        context "with nil override" do
+          subject { schematic.fabricate(arg1: nil) }
+          it "saves the return value of the block as instance" do
+            expect(subject.arg1).to eq(nil)
+            expect(subject.arg2).to eq(10)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
This fixes a problem where attribute methods would be treated as missing when their override value was set to `nil`.

Instead of relying on the value of the attribute, this commit changes the behavior to use `fetch` on the attributes hash. Only a truly missing attribute will now trigger the `super` call in `method_missing`.